### PR TITLE
feat: PSX CSS system — scanlines, CRT, data rain, palette

### DIFF
--- a/frontend/css/psx.css
+++ b/frontend/css/psx.css
@@ -1,0 +1,137 @@
+/* ═══════════════════════════════════════════════════════════
+   IWAKURA — PSX VISUAL SYSTEM
+   Serial Experiments Lain PSX Game Aesthetic (1998)
+   Import this file FIRST, before any screen-specific CSS.
+   ═══════════════════════════════════════════════════════════ */
+
+/* ── Google Fonts ──────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap');
+
+/* ── Color Palette (CSS custom properties) ─────────────────── */
+:root {
+    --color-bg:             #0a0a1a;
+    --color-bg2:            #0d0d2b;
+    --color-accent-orange:  #ff8c00;
+    --color-accent-cyan:    #00d4aa;
+    --color-accent-purple:  #8b7cc8;
+    --color-text:           #e0e0e0;
+    --color-text-green:     #00ff88;
+    --color-blue-dot:       #3a7bd5;
+}
+
+/* ── Typography classes ────────────────────────────────────── */
+.font-psx  { font-family: 'VT323', monospace; }
+.font-mono { font-family: 'Share Tech Mono', monospace; }
+
+/* ── Scanlines overlay (.scanlines) ────────────────────────── */
+/* Uses ::before to avoid collision with body::after (vignette in style.css). */
+.scanlines::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0, 0, 0, 0.08) 2px,
+        rgba(0, 0, 0, 0.08) 4px
+    );
+    pointer-events: none;
+    z-index: 9999;
+}
+
+/* ── Data rain background (.data-rain) ──────────────────────── */
+/* Optional CSS-only fallback. The canvas approach (data-rain.js) is preferred. */
+.data-rain {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.04;
+}
+
+/* ── Progress dots (● ● ● ○ ○) ─────────────────────────────── */
+.progress-dots {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.progress-dots .pdot,
+.progress-dots .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--color-blue-dot);
+    opacity: 0.2;
+    transition: opacity 0.3s, box-shadow 0.3s;
+}
+
+.progress-dots .pdot.on,
+.progress-dots .dot.on,
+.progress-dots .pdot.filled,
+.progress-dots .dot.filled {
+    opacity: 1;
+    box-shadow: 0 0 8px var(--color-blue-dot);
+}
+
+/* ── Orange divider ─────────────────────────────────────────── */
+.hr-orange {
+    height: 1px;
+    border: none;
+    background: var(--color-accent-orange);
+    box-shadow: 0 0 6px rgba(255, 140, 0, 0.5);
+    margin: 10px 0;
+}
+
+/* ── Gate pass notification ─────────────────────────────────── */
+.gate-pass {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.15em;
+    color: var(--color-text);
+    background: rgba(10, 10, 26, 0.92);
+    border: 1px solid var(--color-accent-orange);
+    padding: 5px 12px;
+    box-shadow: 0 0 10px rgba(255, 140, 0, 0.2);
+}
+
+.gate-pass::before {
+    content: '●';
+    color: var(--color-accent-orange);
+    font-size: 8px;
+}
+
+.gate-pass.granted { border-color: var(--color-text-green); box-shadow: 0 0 10px rgba(0, 255, 136, 0.2); }
+.gate-pass.granted::before { color: var(--color-text-green); }
+.gate-pass.denied  { border-color: #ff4455; box-shadow: 0 0 10px rgba(255, 68, 85, 0.2); }
+.gate-pass.denied::before  { color: #ff4455; }
+
+/* ── Color utilities ────────────────────────────────────────── */
+.text-orange { color: var(--color-accent-orange); }
+.text-cyan   { color: var(--color-accent-cyan); }
+.text-green  { color: var(--color-text-green); }
+.text-purple { color: var(--color-accent-purple); }
+
+/* ── Background utility ─────────────────────────────────────── */
+.bg-psx { background-color: var(--color-bg); }
+
+/* ── Border utilities ───────────────────────────────────────── */
+.border-orange { border: 1px solid var(--color-accent-orange); }
+.border-cyan   { border: 1px solid var(--color-accent-cyan); }
+
+/* ── Glow utilities ─────────────────────────────────────────── */
+.glow-orange {
+    text-shadow:
+        0 0 8px rgba(255, 140, 0, 0.9),
+        0 0 20px rgba(255, 140, 0, 0.5);
+}
+
+.glow-cyan {
+    text-shadow:
+        0 0 8px rgba(0, 212, 170, 0.9),
+        0 0 20px rgba(0, 212, 170, 0.5);
+}

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -39,18 +39,7 @@ html, body {
 }
 
 /* ── CRT Effects ───────────────────────────────────────────── */
-#scanlines {
-    position: fixed; inset: 0;
-    background: repeating-linear-gradient(
-        0deg,
-        transparent,
-        transparent 2px,
-        rgba(0,0,0,0.07) 2px,
-        rgba(0,0,0,0.07) 4px
-    );
-    pointer-events: none;
-    z-index: 9998;
-}
+/* Scanlines handled by body.scanlines::before in psx.css */
 
 /* CRT vignette */
 body::after {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,12 +6,13 @@
     <title>IWAKURA // WIRED ACCESS POINT</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/psx.css">
     <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body class="scanlines">
 
-<!-- CRT Scanlines overlay -->
-<div id="scanlines"></div>
+<!-- Background data rain canvas injected by data-rain.js -->
+<!-- Scanlines handled by body.scanlines::before (psx.css) -->
 
 <!-- ── BOOT SCREEN ─────────────────────────────────────── -->
 <div id="screen-boot" class="screen active">
@@ -162,6 +163,7 @@
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="js/data-rain.js"></script>
 <script src="js/audio.js"></script>
 <script src="js/effects.js"></script>
 <script src="js/chat.js"></script>

--- a/frontend/js/data-rain.js
+++ b/frontend/js/data-rain.js
@@ -1,0 +1,99 @@
+/* ═══════════════════════════════════════════════════════════
+   IWAKURA — Background Data Rain
+   Creates a fixed canvas with very subtle falling katakana.
+   z-index: -1, opacity ~0.04 — never distracting.
+   Respects prefers-reduced-motion.
+   ═══════════════════════════════════════════════════════════ */
+
+(function () {
+    'use strict';
+
+    // Respect prefers-reduced-motion
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (motionQuery && motionQuery.matches) return;
+
+    const CHARS =
+        'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホ' +
+        'マミムメモヤユヨラリルレロワヲン' +
+        '0123456789';
+
+    const FONT_SIZE  = 14;
+    const COL_WIDTH  = 16;
+    const BASE_ALPHA = 0.035; // very subtle — spec says ≤ 0.05
+
+    const canvas = document.createElement('canvas');
+    canvas.id = 'bg-data-rain';
+    canvas.style.cssText = [
+        'position:fixed',
+        'top:0',
+        'left:0',
+        'width:100%',
+        'height:100%',
+        'z-index:-1',
+        'pointer-events:none',
+    ].join(';');
+
+    document.body.insertBefore(canvas, document.body.firstChild);
+
+    const ctx = canvas.getContext('2d');
+    let cols  = [];
+    let frameId = null;
+
+    function resize() {
+        canvas.width  = window.innerWidth;
+        canvas.height = window.innerHeight;
+        initCols();
+    }
+
+    function initCols() {
+        const n = Math.floor(canvas.width / COL_WIDTH);
+        cols = Array.from({ length: n }, () => ({
+            y:     -(Math.random() * (canvas.height / FONT_SIZE)),
+            speed: 0.2 + Math.random() * 0.5,
+            len:   3 + Math.floor(Math.random() * 6),
+        }));
+    }
+
+    function frame() {
+        // Fade background very slowly so trails don't linger
+        ctx.fillStyle = 'rgba(10, 10, 26, 0.04)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        ctx.font = `${FONT_SIZE}px "Share Tech Mono", monospace`;
+
+        cols.forEach(function (col, i) {
+            const x  = i * COL_WIDTH + 2;
+            const y0 = col.y * FONT_SIZE;
+
+            // Lead character — slightly brighter
+            const lead = CHARS[Math.floor(Math.random() * CHARS.length)];
+            ctx.fillStyle = `rgba(0, 255, 136, ${BASE_ALPHA * 1.5})`;
+            ctx.fillText(lead, x, y0);
+
+            // Trail — fading
+            for (let j = 1; j < col.len; j++) {
+                const c = CHARS[Math.floor(Math.random() * CHARS.length)];
+                const a = BASE_ALPHA * (1 - j / col.len);
+                ctx.fillStyle = `rgba(0, 255, 136, ${a})`;
+                ctx.fillText(c, x, y0 - j * FONT_SIZE);
+            }
+
+            col.y += col.speed;
+            if (col.y * FONT_SIZE > canvas.height + 100) {
+                col.y     = -(2 + Math.floor(Math.random() * 8));
+                col.speed = 0.2 + Math.random() * 0.5;
+                col.len   = 3 + Math.floor(Math.random() * 6);
+            }
+        });
+
+        frameId = requestAnimationFrame(frame);
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+
+    // Start after a short delay so the boot screen takes visual focus first
+    setTimeout(function () {
+        frameId = requestAnimationFrame(frame);
+    }, 100);
+}());


### PR DESCRIPTION
## Summary

- Adds `frontend/css/psx.css` — foundational CSS with `--color-*` custom properties, `.scanlines`, `.progress-dots`, `.hr-orange`, `.gate-pass`, font and utility classes
- Adds `frontend/js/data-rain.js` — very subtle fixed-background canvas (z-index: -1, opacity ~0.035) with katakana rain; respects `prefers-reduced-motion`
- Updates `index.html`: links `psx.css` first, adds `scanlines` class to `<body>`, includes `data-rain.js`
- Migrates scanlines from `#scanlines` div to `body.scanlines::before` (cleaner, class-based)

Closes #8

## Test plan

- [ ] Load `http://localhost:8790` — PSX aesthetic visible (navy bg, orange accents, monospace fonts)
- [ ] Scanlines visible but subtle (opacity ≤ 0.1)
- [ ] Background data rain visible but not distracting (opacity ≤ 0.05)
- [ ] CRT vignette still present (body::after in style.css unchanged)
- [ ] `var(--color-*)` variables available for use in other CSS files
- [ ] No JS framework dependencies introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)