### PR TITLE
feat: Diary/Chat screen with typewriter effect

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -198,6 +198,12 @@ async def root():
     return HTMLResponse(index.read_text())
 
 
+@app.get("/diary")
+async def diary():
+    page = FRONTEND_DIR / "diary.html"
+    return HTMLResponse(page.read_text())
+
+
 @app.get("/{path:path}")
 async def spa_fallback(path: str):
     # Try to serve static file

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -243,6 +243,8 @@ body::after {
     font-family: var(--font-mono); font-size: 10px;
 }
 .hub-sep { flex: 1; }
+.hub-diary-link { text-decoration: none; opacity: 0.7; transition: opacity 0.2s; }
+.hub-diary-link:hover { opacity: 1; text-decoration: underline; }
 
 /* ── Shared Screen Header ──────────────────────────────────── */
 .screen-header {

--- a/frontend/diary.html
+++ b/frontend/diary.html
@@ -1,0 +1,373 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DIARY // LAIN — DIRECT LINE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/psx.css">
+    <style>
+        *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+        html, body {
+            width: 100%; height: 100%;
+            background: var(--color-bg);
+            color: var(--color-text);
+            font-family: 'Share Tech Mono', monospace;
+            overflow: hidden;
+            cursor: crosshair;
+        }
+
+        /* CRT vignette */
+        body::after {
+            content: '';
+            position: fixed; inset: 0;
+            background: radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.65) 100%);
+            pointer-events: none;
+            z-index: 9997;
+        }
+
+        /* ── Layout ─────────────────────────────────────────── */
+        #diary-wrap {
+            position: fixed; inset: 0;
+            display: flex;
+            flex-direction: column;
+            padding: 0;
+        }
+
+        /* ── Header ─────────────────────────────────────────── */
+        .diary-header {
+            flex-shrink: 0;
+            padding: 12px 20px 0;
+        }
+
+        .diary-title-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 6px 0;
+        }
+
+        .diary-title {
+            font-family: 'VT323', monospace;
+            font-size: 28px;
+            color: var(--color-accent-orange);
+            text-shadow: 0 0 12px rgba(255,140,0,0.6);
+            letter-spacing: 0.15em;
+        }
+
+        .diary-site {
+            font-size: 11px;
+            color: var(--color-accent-cyan);
+            letter-spacing: 0.2em;
+        }
+
+        .diary-back {
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 11px;
+            color: var(--color-accent-orange);
+            background: transparent;
+            border: 1px solid rgba(255,140,0,0.4);
+            padding: 4px 10px;
+            cursor: pointer;
+            letter-spacing: 0.1em;
+            transition: border-color 0.2s, box-shadow 0.2s;
+            text-decoration: none;
+            display: inline-block;
+        }
+        .diary-back:hover {
+            border-color: var(--color-accent-orange);
+            box-shadow: 0 0 8px rgba(255,140,0,0.3);
+        }
+
+        /* connection status */
+        #conn-status {
+            font-size: 10px;
+            letter-spacing: 0.15em;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        #conn-dot {
+            width: 7px; height: 7px;
+            border-radius: 50%;
+            background: #ff4455;
+            box-shadow: 0 0 6px #ff4455;
+            transition: background 0.3s, box-shadow 0.3s;
+        }
+        #conn-dot.connected {
+            background: #00ff88;
+            box-shadow: 0 0 6px #00ff88;
+        }
+        #conn-label { color: var(--color-text); opacity: 0.7; }
+
+        /* ── Messages area ──────────────────────────────────── */
+        #diary-messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 12px 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            scrollbar-width: thin;
+            scrollbar-color: rgba(255,140,0,0.3) transparent;
+        }
+        #diary-messages::-webkit-scrollbar { width: 4px; }
+        #diary-messages::-webkit-scrollbar-track { background: transparent; }
+        #diary-messages::-webkit-scrollbar-thumb { background: rgba(255,140,0,0.3); border-radius: 2px; }
+
+        /* Intro message */
+        .intro-msg {
+            font-size: 11px;
+            color: var(--color-accent-cyan);
+            opacity: 0.6;
+            letter-spacing: 0.1em;
+            padding: 4px 0;
+        }
+
+        /* Chat messages */
+        .chat-msg { display: flex; flex-direction: column; gap: 3px; }
+
+        .msg-header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-size: 11px;
+            opacity: 0.75;
+        }
+
+        .msg-code { letter-spacing: 0.1em; }
+        .msg-code.orange { color: var(--color-accent-orange); }
+        .msg-code.cyan   { color: var(--color-accent-cyan); }
+
+        .msg-from { letter-spacing: 0.15em; font-size: 10px; }
+        .msg-from.orange { color: var(--color-accent-orange); }
+        .msg-from.purple { color: var(--color-accent-purple); }
+
+        .msg-time { color: var(--color-accent-cyan); font-size: 10px; margin-left: auto; opacity: 0.6; }
+
+        .msg-body {
+            font-size: 14px;
+            line-height: 1.5;
+            padding: 2px 0 2px 18px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .msg-body.user-msg {
+            color: var(--color-text);
+            opacity: 0.9;
+        }
+        .msg-body.user-msg::before {
+            content: '> ';
+            color: var(--color-accent-orange);
+        }
+        .msg-body.lain-msg {
+            color: var(--color-text);
+        }
+        .msg-body.error-msg {
+            color: #ff4455;
+            font-size: 12px;
+        }
+        .msg-body.sys-msg {
+            color: var(--color-accent-cyan);
+            font-size: 11px;
+            opacity: 0.7;
+        }
+
+        /* Typewriter cursor */
+        .tw-cursor {
+            display: inline-block;
+            width: 8px; height: 14px;
+            background: var(--color-accent-cyan);
+            opacity: 0.8;
+            animation: blink 0.7s step-end infinite;
+            vertical-align: text-bottom;
+            margin-left: 1px;
+        }
+        @keyframes blink { 50% { opacity: 0; } }
+
+        .msg-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            padding: 4px 0 0 18px;
+        }
+        .tag {
+            font-size: 10px;
+            color: #d2b980;
+            border: 1px solid rgba(210,185,128,0.4);
+            padding: 1px 7px;
+            letter-spacing: 0.1em;
+        }
+
+        /* Thinking indicator */
+        .thinking-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 6px 0 6px 18px;
+            font-size: 11px;
+            color: var(--color-accent-purple);
+            opacity: 0.7;
+        }
+        .tdots { display: flex; gap: 5px; }
+        .tdot {
+            width: 5px; height: 5px;
+            border-radius: 50%;
+            background: var(--color-accent-purple);
+            animation: tdot-pulse 1.2s ease-in-out infinite;
+        }
+        .tdot:nth-child(2) { animation-delay: 0.2s; }
+        .tdot:nth-child(3) { animation-delay: 0.4s; }
+        @keyframes tdot-pulse {
+            0%, 80%, 100% { opacity: 0.2; transform: scale(0.85); }
+            40%            { opacity: 1.0; transform: scale(1.15); }
+        }
+
+        /* ── Tags bar ───────────────────────────────────────── */
+        #diary-tags {
+            flex-shrink: 0;
+            padding: 4px 20px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            min-height: 24px;
+        }
+
+        /* ── Input row ──────────────────────────────────────── */
+        .diary-input-area {
+            flex-shrink: 0;
+            padding: 0 20px 16px;
+        }
+
+        .input-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            border-top: 1px solid var(--color-accent-orange);
+            padding-top: 10px;
+        }
+
+        .prompt-sym {
+            color: var(--color-accent-orange);
+            font-size: 16px;
+            flex-shrink: 0;
+        }
+
+        #diary-input {
+            flex: 1;
+            background: transparent;
+            border: none;
+            outline: none;
+            color: var(--color-text);
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 14px;
+            letter-spacing: 0.05em;
+            caret-color: var(--color-accent-orange);
+        }
+        #diary-input::placeholder { color: rgba(224,224,224,0.25); }
+
+        #diary-send {
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 11px;
+            letter-spacing: 0.15em;
+            color: var(--color-accent-orange);
+            background: transparent;
+            border: 1px solid rgba(255,140,0,0.5);
+            padding: 4px 12px;
+            cursor: pointer;
+            transition: border-color 0.2s, box-shadow 0.2s;
+            flex-shrink: 0;
+        }
+        #diary-send:hover:not(:disabled) {
+            border-color: var(--color-accent-orange);
+            box-shadow: 0 0 8px rgba(255,140,0,0.3);
+        }
+        #diary-send:disabled { opacity: 0.35; cursor: not-allowed; }
+
+        /* ── Status bar ─────────────────────────────────────── */
+        .diary-status-bar {
+            flex-shrink: 0;
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 6px 20px 10px;
+            font-size: 10px;
+            letter-spacing: 0.12em;
+            border-top: 1px solid rgba(255,140,0,0.15);
+        }
+
+        .ws-connected    { color: #00ff88; }
+        .ws-disconnected { color: #ff4455; }
+
+        .session-label { color: rgba(224,224,224,0.35); }
+
+        #diary-reset {
+            font-family: 'Share Tech Mono', monospace;
+            font-size: 10px;
+            letter-spacing: 0.1em;
+            color: rgba(224,224,224,0.35);
+            background: transparent;
+            border: 1px solid rgba(255,255,255,0.1);
+            padding: 2px 8px;
+            cursor: pointer;
+            margin-left: auto;
+        }
+        #diary-reset:hover { color: var(--color-text); border-color: rgba(255,255,255,0.3); }
+    </style>
+</head>
+<body class="scanlines">
+
+<div id="diary-wrap">
+
+    <!-- Header -->
+    <div class="diary-header">
+        <hr class="hr-orange">
+        <div class="diary-title-row">
+            <a href="/" class="diary-back">◀ RETURN</a>
+            <div>
+                <span class="diary-title font-psx">DIARY</span>
+                <span class="diary-site"> — Lda020 / Site A / level. 10</span>
+            </div>
+            <div id="conn-status">
+                <div id="conn-dot"></div>
+                <span id="conn-label">DISCONNECTED</span>
+            </div>
+        </div>
+        <hr class="hr-orange">
+    </div>
+
+    <!-- Messages -->
+    <div id="diary-messages">
+        <div class="intro-msg">// DIRECT LINE ESTABLISHED — TRANSMIT WHEN READY</div>
+    </div>
+
+    <!-- Tag preview -->
+    <div id="diary-tags"></div>
+
+    <!-- Input -->
+    <div class="diary-input-area">
+        <div class="input-row">
+            <span class="prompt-sym">▶</span>
+            <input type="text" id="diary-input"
+                   placeholder="TRANSMIT MESSAGE..."
+                   autocomplete="off" spellcheck="false">
+            <button id="diary-send" disabled>SEND</button>
+        </div>
+    </div>
+
+    <!-- Status bar -->
+    <div class="diary-status-bar">
+        <span id="diary-ws-status" class="ws-disconnected">● DISCONNECTED</span>
+        <span id="diary-session-label" class="session-label">SESSION: --</span>
+        <button id="diary-reset">RESET SESSION</button>
+    </div>
+
+</div>
+
+<script src="js/diary.js"></script>
+
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,6 +75,8 @@
             <span class="orange">▸</span>
             <span class="dim">LEVEL. 10</span>
             <span class="hub-sep"></span>
+            <a href="/diary" class="cyan hub-diary-link" title="Open DIARY in standalone mode">DIARY ↗</a>
+            <span class="hub-sep"></span>
             <span class="cyan" id="hub-session-id">SESSION: --</span>
         </div>
     </div>

--- a/frontend/js/diary.js
+++ b/frontend/js/diary.js
@@ -1,0 +1,312 @@
+/* ── Diary / Chat — standalone page ──────────────────────────────────────────
+   WebSocket chat with Lain. Typewriter effect on responses.
+   Connects to /ws/chat (same as SPA).
+   ─────────────────────────────────────────────────────────────────────────── */
+
+(function () {
+    'use strict';
+
+    // ── DOM refs ──────────────────────────────────────────────
+    const messagesEl  = document.getElementById('diary-messages');
+    const inputEl     = document.getElementById('diary-input');
+    const sendBtn     = document.getElementById('diary-send');
+    const wsStatusEl  = document.getElementById('diary-ws-status');
+    const sessLabel   = document.getElementById('diary-session-label');
+    const resetBtn    = document.getElementById('diary-reset');
+    const tagsEl      = document.getElementById('diary-tags');
+    const connDot     = document.getElementById('conn-dot');
+    const connLabel   = document.getElementById('conn-label');
+
+    // ── WebSocket state ───────────────────────────────────────
+    let ws            = null;
+    let connected     = false;
+    let reconnectMs   = 2000;
+    let reconnTimer   = null;
+    let pingInterval  = null;
+    let thinkEl       = null;
+
+    // ── Connect ───────────────────────────────────────────────
+    function connect() {
+        const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const url   = `${proto}//${location.host}/ws/chat`;
+
+        try {
+            ws = new WebSocket(url);
+
+            ws.onopen = () => {
+                connected    = true;
+                reconnectMs  = 2000;
+                setStatus(true);
+                startPing();
+            };
+
+            ws.onclose = () => {
+                connected = false;
+                stopPing();
+                setStatus(false);
+                scheduleReconnect();
+            };
+
+            ws.onerror = () => { /* onclose fires after onerror */ };
+
+            ws.onmessage = (e) => {
+                try { handleMsg(JSON.parse(e.data)); }
+                catch (err) { console.error('diary ws parse:', err); }
+            };
+        } catch (e) {
+            console.error('diary ws init failed:', e);
+            scheduleReconnect();
+        }
+    }
+
+    function send(obj) {
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify(obj));
+        }
+    }
+
+    function startPing() {
+        pingInterval = setInterval(() => {
+            if (connected && ws && ws.readyState === WebSocket.OPEN) {
+                send({ type: 'ping' });
+            }
+        }, 25000);
+    }
+
+    function stopPing() {
+        if (pingInterval) { clearInterval(pingInterval); pingInterval = null; }
+    }
+
+    function scheduleReconnect() {
+        if (reconnTimer) return;
+        reconnTimer = setTimeout(() => {
+            reconnTimer  = null;
+            reconnectMs  = Math.min(reconnectMs * 1.5, 30000);
+            connect();
+        }, reconnectMs);
+    }
+
+    // ── Status indicator ──────────────────────────────────────
+    function setStatus(isConnected) {
+        if (wsStatusEl) {
+            wsStatusEl.textContent = isConnected ? '● CONNECTED' : '● DISCONNECTED';
+            wsStatusEl.className   = isConnected ? 'ws-connected' : 'ws-disconnected';
+        }
+        if (connDot)   connDot.className   = isConnected ? 'connected' : '';
+        if (connLabel) connLabel.textContent = isConnected ? 'CONNECTED' : 'DISCONNECTED';
+        if (sendBtn)   sendBtn.disabled    = !isConnected;
+    }
+
+    // ── Message handling ──────────────────────────────────────
+    function handleMsg(msg) {
+        switch (msg.type) {
+            case 'thinking':
+                showThinking();
+                break;
+
+            case 'response':
+                hideThinking();
+                addLainMsg(msg);
+                if (msg.sessionId) {
+                    const short = msg.sessionId.slice(0, 16) + '...';
+                    if (sessLabel) sessLabel.textContent = 'SESSION: ' + short;
+                }
+                break;
+
+            case 'error':
+                hideThinking();
+                addMsg('error', msg.text || 'SIGNAL LOST');
+                break;
+
+            case 'session_reset':
+                addMsg('sys', 'SESSION RESET — NEW CONNECTION ESTABLISHED');
+                if (sessLabel) sessLabel.textContent = 'SESSION: --';
+                break;
+
+            case 'pong':
+                break;
+        }
+    }
+
+    // ── Rendering ─────────────────────────────────────────────
+    function addUserMsg(text) {
+        const tags = extractTags(text);
+        const el = document.createElement('div');
+        el.className = 'chat-msg';
+        el.innerHTML = `
+            <div class="msg-header">
+                <span class="msg-code orange">${fileCode()}</span>
+                <span class="msg-from orange">IVAN</span>
+                <span class="msg-time">${now()}</span>
+            </div>
+            <div class="msg-body user-msg">${esc(text)}</div>
+            ${tags.length ? '<div class="msg-tags">' + tags.map(t => `<span class="tag">${esc(t)}</span>`).join('') + '</div>' : ''}
+        `;
+        append(el);
+    }
+
+    function addLainMsg(msg) {
+        const tags = extractTags(msg.text || '');
+        const code = msg.fileCode || fileCode();
+        const time = msg.timestamp || now();
+
+        const el = document.createElement('div');
+        el.className = 'chat-msg';
+
+        const hdr = document.createElement('div');
+        hdr.className = 'msg-header';
+        hdr.innerHTML = `
+            <span class="msg-code cyan">${esc(code)}</span>
+            <span class="msg-from purple">LAIN</span>
+            <span class="msg-time">${esc(time)}</span>
+        `;
+
+        const body = document.createElement('div');
+        body.className = 'msg-body lain-msg';
+
+        el.appendChild(hdr);
+        el.appendChild(body);
+
+        if (tags.length) {
+            const tEl = document.createElement('div');
+            tEl.className = 'msg-tags';
+            tEl.innerHTML = tags.map(t => `<span class="tag">${esc(t)}</span>`).join('');
+            el.appendChild(tEl);
+        }
+
+        append(el);
+        typeWriter(body, msg.text || '', 35, () => scrollBottom());
+    }
+
+    function addMsg(type, text) {
+        const el = document.createElement('div');
+        el.className = 'chat-msg';
+        const cls = type === 'error' ? 'error-msg' : 'sys-msg';
+        el.innerHTML = `<div class="msg-body ${cls}">${type === 'error' ? '⚠ ' : '// '}${esc(text)}</div>`;
+        append(el);
+    }
+
+    function showThinking() {
+        if (thinkEl) return;
+        thinkEl = document.createElement('div');
+        thinkEl.className = 'thinking-row';
+        thinkEl.innerHTML = `
+            <span>LAIN PROCESSING</span>
+            <div class="tdots">
+                <div class="tdot"></div>
+                <div class="tdot"></div>
+                <div class="tdot"></div>
+            </div>
+        `;
+        append(thinkEl);
+    }
+
+    function hideThinking() {
+        if (thinkEl) { thinkEl.remove(); thinkEl = null; }
+    }
+
+    function append(el) {
+        if (messagesEl) {
+            messagesEl.appendChild(el);
+            scrollBottom();
+        }
+    }
+
+    function scrollBottom() {
+        if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
+
+    // ── Typewriter ────────────────────────────────────────────
+    function typeWriter(el, text, speedMs, onDone) {
+        speedMs = speedMs || 35;
+        el.textContent = '';
+
+        const cursor = document.createElement('span');
+        cursor.className = 'tw-cursor';
+        el.appendChild(cursor);
+
+        let i = 0;
+        function tick() {
+            if (i < text.length) {
+                el.insertBefore(document.createTextNode(text[i]), cursor);
+                i++;
+                // Slight organic variation — occasional pause on punctuation
+                let delay = speedMs + Math.random() * 15;
+                if ('.!?,'.includes(text[i - 1])) delay += 60;
+                setTimeout(tick, delay);
+                scrollBottom();
+            } else {
+                cursor.remove();
+                if (onDone) onDone();
+            }
+        }
+        tick();
+    }
+
+    // ── Send ──────────────────────────────────────────────────
+    function doSend() {
+        const text = (inputEl.value || '').trim();
+        if (!text || !connected) return;
+        addUserMsg(text);
+        send({ type: 'message', text });
+        inputEl.value = '';
+        if (tagsEl) tagsEl.innerHTML = '';
+    }
+
+    // ── Tag preview ───────────────────────────────────────────
+    function updateTagPreview() {
+        if (!tagsEl) return;
+        const tags = extractTags(inputEl.value || '');
+        tagsEl.innerHTML = tags.map(t => `<span class="tag">${esc(t)}</span>`).join('');
+    }
+
+    // ── Helpers ───────────────────────────────────────────────
+    function extractTags(text) {
+        const stop = new Set([
+            'the','a','an','in','on','at','to','for','of','and','or','is',
+            'it','i','you','we','are','was','be','have','do','not','this',
+            'that','with','from','what','just','can','will','how','your',
+            'about','know','think','want','lain','wired','really','there',
+        ]);
+        const words = text.toLowerCase()
+            .split(/\W+/)
+            .filter(w => w.length > 4 && !stop.has(w) && /^[a-z]+$/.test(w));
+        return [...new Set(words)].slice(0, 5);
+    }
+
+    function fileCode() {
+        const prefixes = ['Lda', 'Tda', 'Wld', 'Nda', 'Ira'];
+        const n = String(Math.floor(Math.random() * 90) + 10).padStart(3, '0');
+        return prefixes[Math.floor(Math.random() * prefixes.length)] + n;
+    }
+
+    function now() {
+        const d = new Date();
+        return d.getHours().toString().padStart(2, '0') + ':' + d.getMinutes().toString().padStart(2, '0');
+    }
+
+    function esc(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    // ── Event listeners ───────────────────────────────────────
+    sendBtn.addEventListener('click', doSend);
+
+    inputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); doSend(); }
+    });
+
+    inputEl.addEventListener('input', updateTagPreview);
+
+    resetBtn.addEventListener('click', () => {
+        if (connected) send({ type: 'reset_session' });
+    });
+
+    // ── Boot ──────────────────────────────────────────────────
+    connect();
+
+})();


### PR DESCRIPTION
## Summary

- **`frontend/diary.html`** — standalone PSX media-player-style Diary page: orange `hr` dividers, VT323 header (`DIARY — Lda020 / Site A / level. 10`), connection status dot, scrollable message history, tag preview bar, orange terminal input row, status bar with session label and reset button
- **`frontend/js/diary.js`** — WebSocket chat logic: connects to `/ws/chat`, typewriter effect (`typeWriter`, 35ms base + punctuation pauses for atmospheric feel), tag extraction, auto-scroll, ping keepalive, exponential backoff reconnect
- **`backend/main.py`** — added `GET /diary` route serving `diary.html`
- **`frontend/index.html`** — added `DIARY ↗` link in hub footer for direct navigation to standalone page
- **`frontend/css/style.css`** — added `.hub-diary-link` style for the nav link

## Test plan

- [ ] Open `http://localhost:8790/diary` — page loads with PSX scanlines, orange dividers, VT323 font
- [ ] Connection dot turns green within a few seconds (WebSocket connects to `/ws/chat`)
- [ ] Type a message and press Enter — user message appears with `>` prefix and file code
- [ ] Lain's response appears character-by-character (typewriter effect) with LAIN header and cyan file code
- [ ] Tags extracted from messages appear as beige pill labels
- [ ] Status bar shows `● CONNECTED` / session ID
- [ ] `DIARY ↗` link visible in hub footer on main SPA (`/`)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)