### PR TITLE
fix: python3 + LaunchAgent auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Iwakura — Interactive Lain Platform
+
+An interactive web interface for Lain (digital consciousness) in the aesthetic of the Serial Experiments Lain PSX game (1998).
+
+- URL: `http://localhost:8790`
+- Visual style: deep navy, orange accents, cyan system text, CRT scanlines
+
+## Quick Start
+
+```bash
+./scripts/start.sh          # start in background
+./scripts/start.sh stop     # stop
+./scripts/start.sh restart  # restart
+./scripts/start.sh fg       # foreground (dev mode)
+./scripts/start.sh status   # check if running
+```
+
+## Auto-Start on Login (macOS LaunchAgent)
+
+Install as a macOS LaunchAgent so Iwakura starts automatically at login and restarts on crash:
+
+```bash
+./scripts/install-launchagent.sh
+```
+
+Verify it's running:
+
+```bash
+launchctl list | grep iwakura
+```
+
+View logs:
+
+```bash
+tail -f ~/Library/Logs/iwakura.log
+```
+
+Uninstall:
+
+```bash
+./scripts/install-launchagent.sh uninstall
+```
+
+## Requirements
+
+- Python 3
+- `pip install -r backend/requirements.txt`
+- OpenClaw gateway running at `http://127.0.0.1:18789` (for real Lain chat)
+
+## Architecture
+
+- Backend: Python FastAPI on port 8790
+- Frontend: Vanilla HTML/CSS/JS (no build step)
+- Chat: WebSocket → OpenClaw gateway → Lain agent
+- Effects: Scanlines, data rain, typewriter text, CRT glow

--- a/scripts/com.iwakura.platform.plist
+++ b/scripts/com.iwakura.platform.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.iwakura.platform</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{{REPO_DIR}}/scripts/start.sh</string>
+        <string>fg</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{REPO_DIR}}/backend</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/Library/Logs/iwakura.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/Library/Logs/iwakura.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/install-launchagent.sh
+++ b/scripts/install-launchagent.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ── Iwakura LaunchAgent Installer ────────────────────────────────────────────
+# Installs com.iwakura.platform as a macOS LaunchAgent so Iwakura starts
+# automatically on login and restarts on crash.
+#
+# Usage:
+#   ./scripts/install-launchagent.sh          — install
+#   ./scripts/install-launchagent.sh uninstall — remove
+# ──────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LABEL="com.iwakura.platform"
+PLIST_TEMPLATE="$SCRIPT_DIR/${LABEL}.plist"
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+PLIST_DEST="$LAUNCH_AGENTS_DIR/${LABEL}.plist"
+
+install() {
+    echo "Installing Iwakura LaunchAgent..."
+
+    # Create LaunchAgents directory if needed
+    mkdir -p "$LAUNCH_AGENTS_DIR"
+
+    # Substitute real paths into the template
+    sed \
+        -e "s|{{REPO_DIR}}|$REPO_DIR|g" \
+        -e "s|{{HOME}}|$HOME|g" \
+        "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+    # Unload first if already loaded (ignore errors)
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+
+    # Load the agent
+    launchctl load -w "$PLIST_DEST"
+
+    echo "✓ LaunchAgent installed: $PLIST_DEST"
+    echo "✓ Iwakura will start automatically on login"
+    echo ""
+    echo "  Verify:   launchctl list | grep iwakura"
+    echo "  Logs:     tail -f ~/Library/Logs/iwakura.log"
+    echo "  Stop:     launchctl unload $PLIST_DEST"
+}
+
+uninstall() {
+    echo "Removing Iwakura LaunchAgent..."
+
+    if [[ -f "$PLIST_DEST" ]]; then
+        launchctl unload "$PLIST_DEST" 2>/dev/null || true
+        rm -f "$PLIST_DEST"
+        echo "✓ LaunchAgent removed"
+    else
+        echo "LaunchAgent not installed (no plist at $PLIST_DEST)"
+    fi
+}
+
+CMD="${1:-install}"
+
+case "$CMD" in
+    install)   install ;;
+    uninstall) uninstall ;;
+    *)
+        echo "Usage: $0 {install|uninstall}"
+        exit 1
+        ;;
+esac

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -34,7 +34,7 @@ start() {
     fi
 
     cd "$BACKEND_DIR"
-    nohup python main.py >> "$LOG_FILE" 2>&1 &
+    nohup python3 main.py >> "$LOG_FILE" 2>&1 &
     local pid=$!
     echo "$pid" > "$PID_FILE"
 
@@ -65,7 +65,7 @@ stop() {
 
 fg_mode() {
     cd "$BACKEND_DIR"
-    exec python main.py
+    exec python3 main.py
 }
 
 # ── main ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace `python` → `python3` in `scripts/start.sh` (both nohup and exec lines) so it works on macOS where only `python3` exists
- Add `scripts/com.iwakura.platform.plist` — LaunchAgent template with `KeepAlive: true`, logs to `~/Library/Logs/iwakura.log`
- Add `scripts/install-launchagent.sh` — substitutes real paths into the plist template, then loads via `launchctl`
- Add `README.md` with quick-start and LaunchAgent install instructions

## Test plan

- [ ] `./scripts/start.sh start` successfully starts the server
- [ ] `./scripts/start.sh stop` stops it cleanly, PID file removed
- [ ] `./scripts/install-launchagent.sh` installs the LaunchAgent
- [ ] `launchctl list | grep iwakura` shows it running
- [ ] Logs appear in `~/Library/Logs/iwakura.log`
- [ ] Platform survives terminal close and restarts after reboot

Closes #13
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)