### PR TITLE
feat: real OpenClaw chat integration — proxy to lain agent

### DIFF
--- a/backend/gateway.py
+++ b/backend/gateway.py
@@ -1,4 +1,10 @@
-"""OpenClaw gateway client — runs openclaw agent subprocess for synchronous responses."""
+"""OpenClaw gateway client — runs openclaw agent subprocess for synchronous responses.
+
+We use the `openclaw agent --json` CLI rather than the HTTP hooks endpoint because
+POST /hooks/agent is fire-and-forget (returns {"ok":true,"runId":"..."} immediately
+with no way to retrieve the response text via HTTP).  The CLI is synchronous and
+returns the full response inline, which is what the WebSocket chat flow requires.
+"""
 import asyncio
 import json
 import os
@@ -27,7 +33,8 @@ def get_gateway_url() -> str:
 
 
 def get_hook_token() -> str:
-    token = os.environ.get("OPENCLAW_HOOK_TOKEN")
+    # Support both OPENCLAW_TOKEN and OPENCLAW_HOOK_TOKEN
+    token = os.environ.get("OPENCLAW_TOKEN") or os.environ.get("OPENCLAW_HOOK_TOKEN")
     if token:
         return token
     cfg = _read_config()


### PR DESCRIPTION
## Summary

- Wires WebSocket chat to the real lain agent via `openclaw agent --json` CLI
- The HTTP `POST /hooks/agent` endpoint is async (returns `{"ok":true,"runId":"..."}` with no response text), so the CLI is the correct approach for synchronous chat
- Adds `OPENCLAW_TOKEN` env var support as alias for `OPENCLAW_HOOK_TOKEN`
- Session persistence via `.session_id` file carries conversation context across reconnects
- Error handling already in place: unreachable gateway shows `SIGNAL LOST — WIRED UNREACHABLE` in UI

## Test plan

- [x] `gateway.send_message()` returns real Lain response text
- [x] Error path returns `None` → main.py sends `{"type":"error"}` → UI shows error state
- [x] `openclaw agent --agent lain --message "..." --json` works end-to-end
- [x] `OPENCLAW_TOKEN` env var accepted as token override

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)