### PR TITLE
feat: psyche screen live state visualizer

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -569,12 +569,154 @@ body::after {
 /* ── Psyche Screen ─────────────────────────────────────────── */
 .psyche-grid {
     flex: 1; overflow-y: auto;
-    padding: 16px;
-    display: grid; grid-template-columns: 1fr 1fr;
-    gap: 14px; align-content: start;
+    padding: 0 20px 20px;
+    display: flex; flex-direction: column;
+    gap: 0;
     scrollbar-width: thin;
     scrollbar-color: var(--purple-dim) var(--bg-deep);
 }
+.psyche-grid::-webkit-scrollbar { width: 5px; }
+.psyche-grid::-webkit-scrollbar-track { background: var(--bg-deep); }
+.psyche-grid::-webkit-scrollbar-thumb { background: var(--purple-dim); }
+
+/* Glitch flash on refresh */
+@keyframes psyche-glitch {
+    0%   { opacity: 1; filter: brightness(1); }
+    20%  { opacity: 0.6; filter: brightness(2) hue-rotate(20deg); }
+    40%  { opacity: 1; filter: brightness(1.4); }
+    60%  { opacity: 0.8; filter: brightness(1) hue-rotate(-10deg); }
+    100% { opacity: 1; filter: brightness(1); }
+}
+.psyche-glitch { animation: psyche-glitch 0.2s steps(4) forwards; }
+
+/* Header bar */
+.psy-header-bar {
+    display: flex; align-items: center; gap: 14px;
+    padding: 14px 0 8px;
+    font-family: var(--font-mono); font-size: 11px;
+    flex-shrink: 0;
+}
+.psy-file-code { letter-spacing: 0.1em; }
+.psy-title {
+    flex: 1; text-align: center;
+    font-family: var(--font-px); font-size: 8px;
+    color: var(--orange); letter-spacing: 0.4em;
+}
+.psy-ts { font-size: 10px; letter-spacing: 0.08em; }
+
+/* Section rule (horizontal divider) */
+.psy-rule {
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--orange-dim), transparent);
+    margin: 6px 0;
+    flex-shrink: 0;
+}
+
+/* Section title */
+.psy-section-title {
+    font-family: var(--font-px); font-size: 7px;
+    color: var(--orange); letter-spacing: 0.35em;
+    padding: 8px 0 4px;
+    flex-shrink: 0;
+}
+
+/* Section / task rows */
+.psy-section { padding: 4px 0; }
+
+.psy-section-row {
+    display: flex; align-items: baseline; gap: 10px;
+    padding: 3px 0;
+    font-family: var(--font-mono); font-size: 12px;
+}
+.psy-section-row.indent { padding-left: 16px; }
+
+.psy-label {
+    color: var(--green); font-size: 11px; flex-shrink: 0;
+    min-width: 52px;
+}
+.psy-val { color: var(--white); font-size: 12px; flex: 1; }
+.psy-val.cyan { color: var(--cyan); }
+.psy-val.dim  { color: var(--dim); }
+.psy-badge {
+    color: var(--orange); font-family: var(--font-mono); font-size: 10px;
+    flex-shrink: 0; margin-left: auto;
+}
+.psy-key {
+    color: var(--cyan); font-size: 10px; flex-shrink: 0; min-width: 120px;
+    font-family: var(--font-mono);
+}
+
+/* Wave status rows */
+.psy-wave-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 3px 0;
+    font-family: var(--font-mono); font-size: 12px;
+}
+.psy-wave-arrow { color: var(--orange); flex-shrink: 0; }
+.psy-wave-label {
+    color: var(--white); min-width: 80px; flex-shrink: 0; font-size: 11px;
+}
+.wave-dots {
+    display: flex; gap: 5px; align-items: center;
+    flex: 1; flex-wrap: wrap;
+}
+.dot-filled { color: var(--orange); font-size: 13px; line-height: 1; }
+.dot-empty  { color: var(--dim);    font-size: 13px; line-height: 1; }
+.psy-wave-status {
+    font-size: 10px; flex-shrink: 0; letter-spacing: 0.05em;
+    font-family: var(--font-mono);
+}
+.psy-wave-status.dim    { color: var(--dim); }
+.psy-wave-status.orange { color: var(--orange); }
+
+/* Open PR items */
+.psy-pr-item {
+    display: flex; align-items: center; gap: 8px;
+    padding: 3px 0;
+    font-family: var(--font-mono); font-size: 12px;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.psy-pr-item:last-of-type { border-bottom: none; }
+.psy-pr-code  { font-size: 10px; flex-shrink: 0; }
+.psy-pr-arrow { font-size: 11px; flex-shrink: 0; }
+.psy-pr-label {
+    color: var(--white); font-size: 12px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* Notes */
+.psy-note {
+    padding: 3px 0 3px 10px;
+    font-family: var(--font-mono); font-size: 11px;
+    color: var(--dim);
+    border-left: 2px solid rgba(139,124,200,0.4);
+    margin: 2px 0;
+}
+
+/* Metrics line */
+.psy-metrics {
+    padding: 6px 0;
+    font-family: var(--font-mono); font-size: 11px;
+    color: var(--dim); letter-spacing: 0.05em;
+}
+
+/* Preformatted text blocks */
+.psy-pretext {
+    font-family: var(--font-vt); font-size: 17px;
+    line-height: 1.5; white-space: pre-wrap;
+    padding: 6px 0;
+    max-height: 200px; overflow-y: auto;
+}
+.psy-pretext-cyan   { color: rgba(0,212,170,0.75); }
+.psy-pretext-purple { color: rgba(139,124,200,0.85); }
+
+/* Session footer */
+.psy-session {
+    padding: 10px 0 4px;
+    font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em;
+}
+
+/* Legacy card styles kept for backward compatibility */
 .psy-card {
     background: rgba(15,15,53,0.6);
     border: 1px solid rgba(139,124,200,0.3);
@@ -592,8 +734,7 @@ body::after {
     font-family: var(--font-mono); font-size: 12px;
     border-bottom: 1px solid rgba(255,255,255,0.04);
 }
-.psy-key { color: var(--cyan); flex-shrink: 0; min-width: 130px; font-size: 10px; }
-.psy-val { color: var(--white); }
+.psy-field:last-child { border-bottom: none; }
 .psy-val.hi { color: var(--orange); }
 .psy-val.lo { color: var(--dim); }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -170,6 +170,7 @@
 <script src="js/effects.js"></script>
 <script src="js/chat.js"></script>
 <script src="js/nav.js"></script>
+<script src="js/psyche.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -10,6 +10,7 @@
     let currentScreen = 'boot';
     let orbNav        = null;
     let chat          = null;
+    let psyche        = null;
 
     // ── DOM refs ──────────────────────────────────────────────
     const screens = {
@@ -49,6 +50,9 @@
 
             // Stop hub Three.js when leaving
             if (name !== 'hub' && orbNav) orbNav.stop();
+
+            // Stop psyche auto-refresh when leaving psyche
+            if (name !== 'psyche' && psyche) psyche.stop();
         };
 
         if (skipGlitch) {
@@ -421,125 +425,15 @@
 
     // ── Psyche Screen ─────────────────────────────────────────
 
-    async function loadPsyche() {
+    function loadPsyche() {
         const el = document.getElementById('psyche-content');
         if (!el) return;
-        el.innerHTML = '<div class="screen-loading purple">ACCESSING INNER LAYERS<span class="loading-dots"></span></div>';
 
-        try {
-            const res  = await fetch('/api/psyche');
-            const data = await res.json();
-            renderPsyche(el, data);
-        } catch (e) {
-            el.innerHTML = '<div class="screen-loading red">INNER LAYERS INACCESSIBLE</div>';
+        if (!psyche) {
+            el.innerHTML = '<div class="screen-loading purple">ACCESSING INNER LAYERS<span class="loading-dots"></span></div>';
+            psyche = new IwakuraPsyche(el);
         }
-    }
-
-    function renderPsyche(el, data) {
-        const { state = {}, initiative = {}, think = {}, think_delta = {}, soul_excerpt = '', heartbeat = '', session_id } = data;
-        let html = '';
-
-        // ── State card ──
-        const stateFields = Object.entries(state).slice(0, 12).map(([k, v]) => `
-            <div class="psy-field">
-                <span class="psy-key">${esc(k)}</span>
-                <span class="psy-val ${isHighlight(k, v) ? 'hi' : ''}">${esc(String(v))}</span>
-            </div>
-        `).join('');
-
-        html += `
-            <div class="psy-card">
-                <div class="psy-card-title">CURRENT STATE</div>
-                ${stateFields || '<div class="psy-field"><span class="psy-val lo">NO STATE FILE</span></div>'}
-                ${session_id ? `<div class="psy-field"><span class="psy-key">session</span><span class="psy-val dim">${esc(session_id)}</span></div>` : ''}
-            </div>
-        `;
-
-        // ── Initiative card ──
-        const count = initiative.counter || 0;
-        const maxC  = initiative.max     || 10;
-        const bars  = Array.from({ length: maxC }, (_, i) =>
-            `<div class="ibar ${i < count ? 'filled' : ''}"></div>`
-        ).join('');
-
-        const initFields = Object.entries(initiative).slice(0, 6).map(([k, v]) => `
-            <div class="psy-field">
-                <span class="psy-key">${esc(k)}</span>
-                <span class="psy-val ${k === 'counter' ? 'hi' : ''}">${esc(String(v))}</span>
-            </div>
-        `).join('');
-
-        html += `
-            <div class="psy-card">
-                <div class="psy-card-title">INITIATIVE COUNTER</div>
-                ${count > 0 ? `<div class="init-bars">${bars}</div>` : ''}
-                ${initFields || '<div class="psy-field"><span class="psy-val lo">NO INITIATIVE DATA</span></div>'}
-            </div>
-        `;
-
-        // ── Think state ──
-        const thinkFields = Object.entries(think).slice(0, 8).map(([k, v]) => `
-            <div class="psy-field">
-                <span class="psy-key">${esc(k)}</span>
-                <span class="psy-val">${esc(String(v)).slice(0, 80)}</span>
-            </div>
-        `).join('');
-
-        if (thinkFields) {
-            html += `
-                <div class="psy-card">
-                    <div class="psy-card-title">THINK STATE</div>
-                    ${thinkFields}
-                </div>
-            `;
-        }
-
-        // ── Think delta ──
-        const deltaFields = Object.entries(think_delta).slice(0, 6).map(([k, v]) => `
-            <div class="psy-field">
-                <span class="psy-key">${esc(k)}</span>
-                <span class="psy-val">${esc(String(v)).slice(0, 80)}</span>
-            </div>
-        `).join('');
-
-        if (deltaFields) {
-            html += `
-                <div class="psy-card">
-                    <div class="psy-card-title">THINK DELTA</div>
-                    ${deltaFields}
-                </div>
-            `;
-        }
-
-        // ── Soul excerpt (full width) ──
-        if (soul_excerpt) {
-            html += `
-                <div class="psy-card full">
-                    <div class="psy-card-title">SOUL.md EXCERPT</div>
-                    <div class="soul-text">${esc(soul_excerpt)}</div>
-                </div>
-            `;
-        }
-
-        // ── Heartbeat (full width) ──
-        if (heartbeat) {
-            html += `
-                <div class="psy-card full">
-                    <div class="psy-card-title">HEARTBEAT</div>
-                    <div class="hb-text">${esc(heartbeat)}</div>
-                </div>
-            `;
-        }
-
-        if (!html) {
-            html = '<div class="screen-loading dim">PSYCHE DATA NOT ACCESSIBLE</div>';
-        }
-
-        el.innerHTML = html;
-    }
-
-    function isHighlight(k, v) {
-        return ['mood', 'focus', 'energy', 'status', 'state', 'mode'].some(x => k.toLowerCase().includes(x));
+        psyche.init();
     }
 
     // ── Back buttons ──────────────────────────────────────────
@@ -616,5 +510,5 @@
     });
 
     // Expose for debugging
-    window.iwakura = { showScreen, loadStatus, loadMemory, loadPsyche };
+    window.iwakura = { showScreen, loadStatus, loadMemory, loadPsyche, getPsyche: () => psyche };
 })();

--- a/frontend/js/psyche.js
+++ b/frontend/js/psyche.js
@@ -1,0 +1,273 @@
+/* ── Iwakura Platform — Psyche Screen ────────────────────────────────────────
+   Fetches /api/psyche every 30s, renders PSX-style Lain internal state terminal
+   ─────────────────────────────────────────────────────────────────────────── */
+
+(function () {
+    'use strict';
+
+    class IwakuraPsyche {
+        constructor(contentEl) {
+            this._el = contentEl;
+            this._timer = null;
+        }
+
+        init() {
+            this._fetch();
+            if (this._timer) clearInterval(this._timer);
+            this._timer = setInterval(() => this._fetch(), 30000);
+        }
+
+        stop() {
+            if (this._timer) { clearInterval(this._timer); this._timer = null; }
+        }
+
+        async _fetch() {
+            try {
+                const res = await fetch('/api/psyche');
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                const data = await res.json();
+                this._render(data);
+                this._glitch();
+            } catch (e) {
+                // Keep existing content on repeated failures; only show error on first load
+                if (this._el.querySelector('.screen-loading')) {
+                    this._el.innerHTML = '<div class="screen-loading red">INNER LAYERS INACCESSIBLE</div>';
+                }
+            }
+        }
+
+        _glitch() {
+            this._el.classList.add('psyche-glitch');
+            setTimeout(() => this._el.classList.remove('psyche-glitch'), 200);
+        }
+
+        _render(data) {
+            const {
+                state = {},
+                initiative = {},
+                think = {},
+                session_id,
+                soul_excerpt = '',
+                heartbeat = '',
+            } = data;
+
+            let html = '';
+
+            // ── Header bar ──
+            const ts = new Date().toISOString().slice(11, 19) + 'Z';
+            html += `
+                <div class="psy-header-bar">
+                    <span class="psy-file-code green">Lda077</span>
+                    <span class="psy-title">LAIN INTERNAL STATE</span>
+                    <span class="psy-ts dim">${ts}</span>
+                </div>
+                <div class="psy-rule"></div>
+            `;
+
+            // ── Current Task ──
+            const rawTasks = state.tasks || state.task || null;
+            const task = Array.isArray(rawTasks) ? rawTasks[0]
+                       : (rawTasks && typeof rawTasks === 'object') ? rawTasks
+                       : rawTasks ? { name: String(rawTasks) } : null;
+
+            if (task) {
+                const taskName   = task.name || task.project || String(task);
+                const taskGoal   = task.goal || task.description || '';
+                const taskStatus = task.status || 'ACTIVE';
+                html += `
+                    <div class="psy-section">
+                        <div class="psy-section-row">
+                            <span class="psy-label">TASK:</span>
+                            <span class="psy-val cyan">${esc(taskName)}</span>
+                            <span class="psy-badge">[${esc(taskStatus.toUpperCase())}]</span>
+                        </div>
+                        ${taskGoal ? `<div class="psy-section-row indent">
+                            <span class="psy-label dim">Goal:</span>
+                            <span class="psy-val dim">${esc(taskGoal)}</span>
+                        </div>` : ''}
+                    </div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Wave Status ──
+            const waveStatus = state.wave_status || state.waves || null;
+            if (waveStatus) {
+                html += `<div class="psy-section-title">WAVE STATUS</div>`;
+                const waves = Array.isArray(waveStatus) ? waveStatus
+                            : (typeof waveStatus === 'object') ? Object.entries(waveStatus).map(([k, v]) => ({ label: k, ...v }))
+                            : [];
+                waves.forEach(wave => { html += renderWave(wave); });
+                html += `<div class="psy-rule"></div>`;
+            }
+
+            // ── Open PRs ──
+            const prs = state.open_prs || state.prs || null;
+            const prList = Array.isArray(prs) ? prs
+                         : (prs && typeof prs === 'object') ? Object.values(prs)
+                         : [];
+            if (prList.length > 0) {
+                html += `<div class="psy-section-title">OPEN PRs</div>`;
+                prList.slice(0, 8).forEach((pr, i) => {
+                    const code  = 'Pr' + String(i + 1).padStart(3, '0');
+                    const label = typeof pr === 'string' ? pr : (pr.title || pr.name || JSON.stringify(pr));
+                    html += `
+                        <div class="psy-pr-item">
+                            <span class="psy-pr-code green">${code}</span>
+                            <span class="psy-pr-arrow orange">►</span>
+                            <span class="psy-pr-label">${esc(label)}</span>
+                        </div>
+                    `;
+                });
+                html += `<div class="psy-rule"></div>`;
+            }
+
+            // ── Notes ──
+            const rawNotes = state.notes || state.recent_notes || null;
+            const noteList = Array.isArray(rawNotes) ? rawNotes
+                           : typeof rawNotes === 'string' ? rawNotes.split('\n').filter(Boolean)
+                           : [];
+            const last3 = noteList.slice(-3);
+            if (last3.length > 0) {
+                html += `<div class="psy-section-title">NOTES (last ${last3.length})</div>`;
+                last3.forEach(note => {
+                    const txt = typeof note === 'string' ? note : JSON.stringify(note);
+                    html += `<div class="psy-note">${esc(txt)}</div>`;
+                });
+                html += `<div class="psy-rule"></div>`;
+            }
+
+            // ── Metrics ──
+            const metrics = state.metrics || null;
+            if (metrics) {
+                let mline = '';
+                if (typeof metrics === 'string') {
+                    mline = esc(metrics);
+                } else {
+                    mline = Object.entries(metrics).map(([k, v]) => `${esc(String(v))} ${esc(k)}`).join(' ▸ ');
+                }
+                html += `
+                    <div class="psy-metrics">METRICS: <span class="cyan">${mline}</span></div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Initiative Counter ──
+            const count = initiative.counter || 0;
+            const maxC  = initiative.max || 10;
+            const hasInit = Object.keys(initiative).length > 0;
+            if (hasInit) {
+                const dots = Array.from({ length: maxC }, (_, i) =>
+                    `<span class="${i < count ? 'dot-filled' : 'dot-empty'}">${i < count ? '●' : '○'}</span>`
+                ).join(' ');
+                const initFields = Object.entries(initiative).filter(([k]) => k !== 'counter' && k !== 'max').slice(0, 4);
+                html += `
+                    <div class="psy-section-title">INITIATIVE COUNTER</div>
+                    <div class="psy-section-row">
+                        <span class="psy-label dim">counter</span>
+                        <span class="wave-dots">${dots}</span>
+                        <span class="psy-val orange">${count}/${maxC}</span>
+                    </div>
+                `;
+                initFields.forEach(([k, v]) => {
+                    html += `
+                        <div class="psy-section-row">
+                            <span class="psy-key">${esc(k)}</span>
+                            <span class="psy-val dim">${esc(String(v)).slice(0, 80)}</span>
+                        </div>
+                    `;
+                });
+                html += `<div class="psy-rule"></div>`;
+            }
+
+            // ── Think State ──
+            const thinkEntries = Object.entries(think).slice(0, 6);
+            if (thinkEntries.length > 0) {
+                html += `<div class="psy-section-title">THINK STATE</div>`;
+                thinkEntries.forEach(([k, v]) => {
+                    html += `
+                        <div class="psy-section-row">
+                            <span class="psy-key">${esc(k)}</span>
+                            <span class="psy-val dim">${esc(String(v)).slice(0, 80)}</span>
+                        </div>
+                    `;
+                });
+                html += `<div class="psy-rule"></div>`;
+            }
+
+            // ── Heartbeat ──
+            if (heartbeat) {
+                html += `
+                    <div class="psy-section-title">HEARTBEAT</div>
+                    <div class="psy-pretext psy-pretext-cyan">${esc(heartbeat)}</div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Soul Excerpt ──
+            if (soul_excerpt) {
+                html += `
+                    <div class="psy-section-title">SOUL.md</div>
+                    <div class="psy-pretext psy-pretext-purple">${esc(soul_excerpt)}</div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Fallback if nothing rendered ──
+            if (!task && !waveStatus && prList.length === 0 && !hasInit && !thinkEntries.length && !heartbeat && !soul_excerpt) {
+                // Show raw state fields as fallback
+                const stateEntries = Object.entries(state).slice(0, 12);
+                if (stateEntries.length > 0) {
+                    html += `<div class="psy-section-title">STATE</div>`;
+                    stateEntries.forEach(([k, v]) => {
+                        html += `
+                            <div class="psy-section-row">
+                                <span class="psy-key">${esc(k)}</span>
+                                <span class="psy-val">${esc(String(v)).slice(0, 100)}</span>
+                            </div>
+                        `;
+                    });
+                } else {
+                    html += '<div class="screen-loading dim">PSYCHE DATA NOT ACCESSIBLE</div>';
+                }
+            }
+
+            // ── Session ──
+            if (session_id) {
+                html += `<div class="psy-session dim">SESSION: ${esc(session_id)}</div>`;
+            }
+
+            this._el.innerHTML = html;
+        }
+    }
+
+    function renderWave(wave) {
+        if (typeof wave === 'string') {
+            return `<div class="psy-wave-row"><span class="psy-wave-label dim">${esc(wave)}</span></div>`;
+        }
+        const label  = wave.label || wave.name || 'Wave';
+        const done   = typeof wave.done === 'number'  ? wave.done  : (parseInt(wave.completed) || 0);
+        const total  = typeof wave.total === 'number' ? wave.total : (parseInt(wave.count) || 5);
+        const status = wave.status || (done >= total ? 'DONE' : 'IN PROGRESS');
+        const dotClass = status === 'DONE' ? 'dim' : 'orange';
+        const dots = Array.from({ length: total }, (_, i) =>
+            `<span class="${i < done ? 'dot-filled' : 'dot-empty'}">${i < done ? '●' : '○'}</span>`
+        ).join(' ');
+        return `
+            <div class="psy-wave-row">
+                <span class="psy-wave-arrow">▸</span>
+                <span class="psy-wave-label">${esc(label)}</span>
+                <span class="wave-dots">${dots}</span>
+                <span class="psy-wave-status ${dotClass}">${esc(status)}</span>
+            </div>
+        `;
+    }
+
+    function esc(s) {
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    window.IwakuraPsyche = IwakuraPsyche;
+})();


### PR DESCRIPTION
## Summary

- Add `frontend/js/psyche.js` — `IwakuraPsyche` class that fetches `/api/psyche` every 30s and renders a PSX-style data terminal (not raw JSON)
- Parse `state.tasks` → current task with `[ACTIVE]` badge
- Parse `state.wave_status` → dot-bar rows (`●` filled / `○` empty) per the spec wireframe
- Parse `state.open_prs` → list with `Pr001`/`Pr002` file codes and `►` arrows
- Parse `state.notes` → last 3 entries with purple-border styling
- Parse `state.metrics` → single summary line with `▸` separators
- On every 30s refresh: 200ms glitch-flash animation (`psyche-glitch` keyframe)
- Wire `app.js` `loadPsyche()` to delegate to `IwakuraPsyche`; stop interval timer when leaving the screen
- New `.psy-*` CSS: header bar, orange rules, section titles, wave-dots, PR items, notes, metrics, pretext blocks

## Test plan

- [ ] Navigate to PSYCHE from hub — screen loads and shows Lain's state (not raw JSON)
- [ ] Wave status section renders dot-bars if `wave_status` present in STATE.yaml
- [ ] Open PRs section shows `Pr001 ► ...` items if `open_prs` present
- [ ] Notes section shows last 3 entries
- [ ] Metrics line renders if `metrics` field present
- [ ] After 30s, screen auto-refreshes with brief glitch flash
- [ ] Navigating away and back stops/restarts the interval correctly
- [ ] Fallback to raw key/value list if STATE.yaml has unrecognized structure

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)