### PR TITLE
feat: Three.js orbital hub navigation (3D rings + bubble nodes)

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -159,10 +159,17 @@ body::after {
     min-width: 90px;
     backdrop-filter: blur(2px);
 }
-.nav-label-item:hover {
+.nav-label-item:hover,
+.nav-label-item.hovered {
     background: rgba(255,140,0,0.15);
     border-color: var(--orange);
     box-shadow: 0 0 18px rgba(255,140,0,0.4);
+}
+/* Cyan override when 3D raycaster detects hover */
+.nav-label-item.hovered {
+    background: rgba(0,212,170,0.15) !important;
+    border-color: var(--cyan) !important;
+    box-shadow: 0 0 18px rgba(0,212,170,0.4) !important;
 }
 .nav-label-item[data-target="status"] { border-color: rgba(0,212,170,0.5); }
 .nav-label-item[data-target="status"]:hover {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -164,7 +164,7 @@
     <span class="vol-label">VOL</span>
 </div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
 <script src="js/data-rain.js"></script>
 <script src="js/audio.js"></script>
 <script src="js/effects.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -137,10 +137,10 @@
             orbNav = new OrbitalNav(canvas, labelsDiv, (id) => {
                 showScreen(id);
             });
+            orbNav.init();
+        } else {
+            orbNav.resume();
         }
-
-        orbNav.running = false;
-        orbNav.init();
 
         // Load session info for footer
         fetch('/api/session')

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -252,7 +252,7 @@ class OrbitalNav {
             if (this.rings[1]) this.rings[1].mesh.rotation.y = t * 0.028;
             if (this.rings[2]) this.rings[2].mesh.rotation.x += 0.0015;
 
-            // Orbit nav meshes
+            // Orbit nav meshes — position + base pulse scale
             this.navMeshes.forEach((mesh, i) => {
                 const base  = this.navDefs[i].baseAngle;
                 const angle = base + t * 0.14;
@@ -263,9 +263,19 @@ class OrbitalNav {
                 );
                 if (mesh.userData.halo) mesh.userData.halo.position.copy(mesh.position);
 
-                // Pulse scale
-                const pulse = 1 + Math.sin(t * 1.8 + i * 1.2) * 0.1;
-                mesh.scale.setScalar(pulse);
+                // Store base pulse scale — hover may multiply it
+                mesh.userData.pulseScale = 1 + Math.sin(t * 1.8 + i * 1.2) * 0.1;
+            });
+
+            // Reset all nodes to default appearance
+            this.navMeshes.forEach(m => {
+                m.material.opacity = m.userData.baseOpacity;
+                m.material.color.setHex(m.userData.color);
+                m.scale.setScalar(m.userData.pulseScale);
+                if (m.userData.halo) {
+                    m.userData.halo.material.opacity = 0.08;
+                    m.userData.halo.material.color.setHex(m.userData.color);
+                }
             });
 
             // Raycaster hover detection
@@ -273,15 +283,15 @@ class OrbitalNav {
             const hits = this.raycaster.intersectObjects(this.navMeshes);
 
             this.hoveredId = null;
-            this.navMeshes.forEach(m => {
-                m.material.opacity = m.userData.baseOpacity;
-                if (m.userData.halo) m.userData.halo.material.opacity = 0.08;
-            });
-
             if (hits.length > 0) {
                 const h = hits[0].object;
                 h.material.opacity = 1.0;
-                if (h.userData.halo) h.userData.halo.material.opacity = 0.3;
+                h.material.color.setHex(0x00d4aa);       // cyan on hover
+                h.scale.setScalar(h.userData.pulseScale * 1.3); // 1.3x scale
+                if (h.userData.halo) {
+                    h.userData.halo.material.opacity = 0.3;
+                    h.userData.halo.material.color.setHex(0x00d4aa);
+                }
                 this.hoveredId = h.userData.navId;
                 this.canvas.style.cursor = 'pointer';
             } else {


### PR DESCRIPTION
## Summary
- Upgrades Three.js CDN to v0.160.0 global build (was r128)
- Fixes `initHub()` to call `orbNav.resume()` on revisit instead of re-calling `orbNav.init()` — previously leaked WebGL contexts and double-ran animation loops
- Hover state now applies 1.3× scale + cyan glow (#00d4aa) to the hovered 3D nav node via raycaster; all nodes reset to their per-def color each frame
- Adds `.nav-label-item.hovered` CSS class so the HTML label overlays track the 3D hover state with matching cyan glow

## Test plan
- [ ] Hub screen shows 3D orbital rings rotating at different tilts/speeds
- [ ] All 4 nodes (DIARY, STATUS, MEMORY, PSYCHE) are clickable and navigate to correct screen
- [ ] Hovering a node scales it to 1.3× and turns it cyan; HTML label also glows cyan
- [ ] Lain center node pulses (scale 0.95–1.05 sine)
- [ ] Navigating away and back to Hub resumes animation without errors or stutter
- [ ] No console errors; smooth 60fps on MacBook

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)