### PR TITLE
feat: STATUS screen — live system dashboard with PSX styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -172,6 +172,7 @@
 <script src="js/nav.js"></script>
 <script src="js/psyche.js"></script>
 <script src="js/memory.js"></script>
+<script src="js/status.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -12,6 +12,7 @@
     let chat          = null;
     let memory        = null;
     let psyche        = null;
+    let statusDash    = null;
 
     // ── DOM refs ──────────────────────────────────────────────
     const screens = {
@@ -57,6 +58,9 @@
 
             // Stop psyche auto-refresh when leaving psyche
             if (name !== 'psyche' && psyche) psyche.stop();
+
+            // Stop status auto-refresh when leaving status
+            if (name !== 'status' && statusDash) statusDash.stop();
         };
 
         if (skipGlitch) {
@@ -222,122 +226,18 @@
 
     // ── Status Screen ─────────────────────────────────────────
 
-    async function loadStatus() {
+    function loadStatus() {
         const el = document.getElementById('status-content');
+        const ts = document.getElementById('status-timestamp');
         if (!el) return;
-        el.innerHTML = '<div class="screen-loading green">SCANNING SYSTEMS<span class="loading-dots"></span></div>';
 
-        try {
-            const res  = await fetch('/api/status');
-            const data = await res.json();
-            renderStatus(el, data);
-
-            const ts = document.getElementById('status-timestamp');
-            if (ts) ts.textContent = data.timestamp || '--';
-        } catch (e) {
-            el.innerHTML = '<div class="screen-loading red">ERROR RETRIEVING STATUS</div>';
+        if (!statusDash) {
+            statusDash = new StatusDashboard();
+        } else {
+            // Re-entering status: stop old interval and restart
+            statusDash.stop();
         }
-    }
-
-    function renderStatus(el, data) {
-        const { crons = [], docker = [], memory = {}, lain = {} } = data;
-        let html = '';
-
-        // ── Memory Usage ──
-        const pct  = memory.percent || 0;
-        const used = memory.used || '?';
-        const free = memory.free || '?';
-        html += `
-            <div class="status-card">
-                <div class="status-card-title">MEMORY USAGE</div>
-                <div class="mem-bar-wrap">
-                    <div class="mem-bar-fill" style="width:${pct}%"></div>
-                </div>
-                <div class="mem-stats">
-                    <span class="cyan">${pct}% USED</span>
-                    <span>${used} / ${free} free</span>
-                </div>
-            </div>
-        `;
-
-        // ── Lain State ──
-        const state      = lain.state || {};
-        const initiative = lain.initiative || {};
-        const stateRows  = Object.entries(state).slice(0, 8).map(([k, v]) => `
-            <div class="srow">
-                <div class="sdot sdot-b"></div>
-                <span class="srow-label">${esc(k)}</span>
-                <span class="srow-val">${esc(String(v))}</span>
-            </div>
-        `).join('');
-
-        html += `
-            <div class="status-card">
-                <div class="status-card-title">LAIN STATE</div>
-                ${stateRows || '<div class="srow"><span class="srow-label dim">NO STATE FILE</span></div>'}
-                ${initiative.counter !== undefined ? `
-                    <div class="srow" style="margin-top:6px">
-                        <div class="sdot sdot-o"></div>
-                        <span class="srow-label">INITIATIVE</span>
-                        <span class="srow-val orange">${initiative.counter} / ${initiative.max || '?'}</span>
-                    </div>
-                ` : ''}
-            </div>
-        `;
-
-        // ── Cron Jobs ──
-        const cronRows = crons.slice(0, 12).map(c => `
-            <div class="srow">
-                <div class="sdot ${c.active ? 'sdot-g' : 'sdot-d'}"></div>
-                <span class="srow-label">${esc(c.command)}</span>
-                <span class="srow-val">${esc(c.schedule)}</span>
-            </div>
-        `).join('');
-
-        html += `
-            <div class="status-card">
-                <div class="status-card-title">CRON JOBS (${crons.length})</div>
-                ${cronRows || '<div class="srow"><span class="srow-label dim">NO CRONS</span></div>'}
-            </div>
-        `;
-
-        // ── Docker ──
-        const dockerRows = docker.slice(0, 8).map(c => {
-            const up = (c.status || '').toLowerCase().includes('up');
-            return `
-                <div class="srow">
-                    <div class="sdot ${up ? 'sdot-g' : 'sdot-r'}"></div>
-                    <span class="srow-label">${esc(c.name)}</span>
-                    <span class="srow-val">${esc(c.status || '--')}</span>
-                </div>
-            `;
-        }).join('');
-
-        html += `
-            <div class="status-card">
-                <div class="status-card-title">DOCKER (${docker.length})</div>
-                ${dockerRows || '<div class="srow"><span class="srow-label dim">NO CONTAINERS</span></div>'}
-            </div>
-        `;
-
-        // ── Memory Files ──
-        const files = (lain.memory_files || []).slice(0, 10);
-        const fileRows = files.map(f => `
-            <div class="srow">
-                <div class="sdot sdot-b"></div>
-                <span class="srow-label">${esc(f.name)}</span>
-                <span class="srow-val">${esc(f.modified || '')} · ${esc(f.size || '')}</span>
-            </div>
-        `).join('');
-
-        html += `
-            <div class="status-card full">
-                <div class="status-card-title">LAIN MEMORY FILES (${files.length})</div>
-                ${fileRows || '<div class="srow"><span class="srow-label dim">NO FILES</span></div>'}
-            </div>
-        `;
-
-        el.innerHTML = html;
+        statusDash.init(el, ts);
     }
 
     // ── Memory Screen ─────────────────────────────────────────
@@ -370,13 +270,22 @@
         });
     });
 
+    // ── Global ESC → return to hub ────────────────────────────
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && currentScreen !== 'boot' && currentScreen !== 'hub') {
+            if (window.audio) window.audio.playClick();
+            showScreen('hub');
+        }
+    });
+
     // ── Status refresh ────────────────────────────────────────
 
     const statusRefresh = document.getElementById('status-refresh');
     if (statusRefresh) {
         statusRefresh.addEventListener('click', () => {
             if (window.audio) window.audio.playClick();
-            loadStatus();
+            if (statusDash) statusDash.refresh();
         });
     }
 
@@ -415,16 +324,6 @@
     document.addEventListener('click',     startAudio, { once: true });
     document.addEventListener('keydown',   startAudio, { once: true });
     document.addEventListener('touchstart', startAudio, { once: true });
-
-    // ── Utility ───────────────────────────────────────────────
-
-    function esc(s) {
-        return String(s)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
-    }
 
     // ── Boot ──────────────────────────────────────────────────
 

--- a/frontend/js/status.js
+++ b/frontend/js/status.js
@@ -1,0 +1,183 @@
+/* ── Iwakura STATUS Dashboard ─────────────────────────────────────────────────
+   Live system dashboard: memory, crons, docker, lain state.
+   Auto-refreshes every 10 seconds while the STATUS screen is active.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+(function () {
+'use strict';
+
+function esc(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+class StatusDashboard {
+    constructor() {
+        this._container  = null;
+        this._tsEl       = null;
+        this._intervalId = null;
+        this._loading    = false;
+    }
+
+    init(containerEl, timestampEl) {
+        this._container = containerEl;
+        this._tsEl      = timestampEl;
+        this.refresh();
+        // Auto-refresh every 10s
+        this._intervalId = setInterval(() => this.refresh(), 10000);
+    }
+
+    stop() {
+        if (this._intervalId) {
+            clearInterval(this._intervalId);
+            this._intervalId = null;
+        }
+    }
+
+    async refresh() {
+        if (this._loading) return;
+        this._loading = true;
+        await this._load();
+        this._loading = false;
+    }
+
+    async _load() {
+        const el = this._container;
+        if (!el) return;
+
+        // Show loading only on first load (container has no cards yet)
+        if (!el.querySelector('.status-card')) {
+            el.innerHTML = '<div class="screen-loading green">SCANNING SYSTEMS<span class="loading-dots"></span></div>';
+        }
+
+        try {
+            const res  = await fetch('/api/status');
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            this._render(el, data);
+
+            if (this._tsEl) {
+                const ts = data.timestamp
+                    ? new Date(data.timestamp).toLocaleTimeString('en-US', { hour12: false })
+                    : '--';
+                this._tsEl.textContent = 'LAST SYNC: ' + ts;
+            }
+        } catch (e) {
+            el.innerHTML = '<div class="screen-loading red">● CONNECTION LOST — RETRYING<span class="loading-dots"></span></div>';
+            if (this._tsEl) this._tsEl.textContent = 'ERROR';
+        }
+    }
+
+    _render(el, data) {
+        const { crons = [], docker = [], memory = {}, lain = {} } = data;
+        let html = '';
+
+        // ── System / Memory ──────────────────────────────────────
+        const pct  = memory.percent || 0;
+        const used = memory.used    || '?';
+        const free = memory.free    || '?';
+        const barColor = pct > 85 ? 'var(--red)' : pct > 65 ? 'var(--orange)' : 'var(--cyan)';
+
+        html += `
+            <div class="status-card">
+                <div class="status-card-title">SYSTEM MEMORY</div>
+                <div class="mem-bar-wrap">
+                    <div class="mem-bar-fill" style="width:${pct}%;background:${barColor}"></div>
+                </div>
+                <div class="mem-stats">
+                    <span style="color:${barColor}">${pct}% USED</span>
+                    <span>${esc(used)} used &nbsp;·&nbsp; ${esc(free)} free</span>
+                </div>
+            </div>
+        `;
+
+        // ── Lain State ───────────────────────────────────────────
+        const state      = lain.state      || {};
+        const initiative = lain.initiative || {};
+        const stateKeys  = Object.keys(state).slice(0, 8);
+        const stateRows  = stateKeys.map(k => `
+            <div class="srow">
+                <div class="sdot sdot-b"></div>
+                <span class="srow-label">${esc(k)}</span>
+                <span class="srow-val">${esc(String(state[k]))}</span>
+            </div>
+        `).join('');
+
+        const initRow = initiative.counter !== undefined ? `
+            <div class="srow" style="margin-top:6px">
+                <div class="sdot sdot-o"></div>
+                <span class="srow-label">INITIATIVE</span>
+                <span class="srow-val orange">${esc(String(initiative.counter))} / ${esc(String(initiative.max || '?'))}</span>
+            </div>
+        ` : '';
+
+        html += `
+            <div class="status-card">
+                <div class="status-card-title">LAIN STATE</div>
+                ${stateRows || '<div class="srow"><span class="srow-label dim">NO STATE FILE</span></div>'}
+                ${initRow}
+            </div>
+        `;
+
+        // ── OpenClaw / Cron Jobs ─────────────────────────────────
+        const cronRows = crons.slice(0, 12).map(c => `
+            <div class="srow">
+                <div class="sdot ${c.active ? 'sdot-g' : 'sdot-d'}"></div>
+                <span class="srow-label">${esc(c.command)}</span>
+                <span class="srow-val">${esc(c.schedule)}</span>
+            </div>
+        `).join('');
+
+        html += `
+            <div class="status-card">
+                <div class="status-card-title">OPENCLAW CRONS (${crons.length})</div>
+                ${cronRows || '<div class="srow"><span class="srow-label dim">NO CRONS</span></div>'}
+            </div>
+        `;
+
+        // ── Docker Containers ────────────────────────────────────
+        const dockerRows = docker.slice(0, 10).map(c => {
+            const up  = (c.status || '').toLowerCase().startsWith('up');
+            const dot = up ? 'sdot-g' : 'sdot-r';
+            return `
+                <div class="srow">
+                    <div class="sdot ${dot}"></div>
+                    <span class="srow-label">${esc(c.name)}</span>
+                    <span class="srow-val">${esc(c.status || '--')}</span>
+                </div>
+            `;
+        }).join('');
+
+        html += `
+            <div class="status-card">
+                <div class="status-card-title">DOCKER (${docker.length})</div>
+                ${dockerRows || '<div class="srow"><span class="srow-label dim">NO CONTAINERS</span></div>'}
+            </div>
+        `;
+
+        // ── Lain Memory Files ────────────────────────────────────
+        const files    = (lain.memory_files || []).slice(0, 12);
+        const fileRows = files.map(f => `
+            <div class="srow">
+                <div class="sdot sdot-b"></div>
+                <span class="srow-label">${esc(f.name)}</span>
+                <span class="srow-val">${esc(f.modified || '')} · ${esc(f.size || '')}</span>
+            </div>
+        `).join('');
+
+        html += `
+            <div class="status-card full">
+                <div class="status-card-title">LAIN MEMORY FILES (${files.length})</div>
+                ${fileRows || '<div class="srow"><span class="srow-label dim">NO FILES</span></div>'}
+            </div>
+        `;
+
+        el.innerHTML = html;
+    }
+}
+
+window.StatusDashboard = StatusDashboard;
+})();


### PR DESCRIPTION
## Summary
- Extracts STATUS screen logic into `frontend/js/status.js` (`StatusDashboard` class)
- Auto-refreshes every 10s without flicker (skips loading spinner on subsequent refreshes)
- Red `● CONNECTION LOST` error state on network failure with animated dots
- Color-coded memory bar (cyan → orange → red as usage rises)
- All four sections: SYSTEM MEMORY, LAIN STATE, OPENCLAW CRONS, DOCKER, LAIN MEMORY FILES
- Global ESC key handler added to return to hub from any screen
- Refresh button wired to `statusDash.refresh()`
- Stops auto-refresh interval when navigating away from STATUS

## Test plan
- [ ] Navigate to STATUS from hub — data loads within 500ms
- [ ] Wait 10s — data refreshes automatically without full page flash
- [ ] Press ESC — returns to hub
- [ ] Click ↻ REFRESH — immediate re-fetch
- [ ] Kill backend — CONNECTION LOST message appears
- [ ] Check all PSX styling: orange headers, green values, dot indicators

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)