### PR TITLE
feat: glitch effects — CRT scanlines, screen flicker, data corruption aesthetic

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -812,6 +812,69 @@ body::after {
 .red    { color: var(--red); }
 .dim    { color: var(--dim); }
 
+/* ── Glitch Effects System ─────────────────────────────────── */
+
+/* CRT Overlay — animated scanlines, configurable via --scanline-opacity */
+.crt-overlay {
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0, 0, 0, var(--scanline-opacity, 0.08)) 2px,
+        rgba(0, 0, 0, var(--scanline-opacity, 0.08)) 4px
+    );
+    pointer-events: none;
+    z-index: 9998;
+    animation: scanline-scroll 8s linear infinite;
+}
+.crt-overlay.no-anim { animation: none; }
+
+@keyframes scanline-scroll {
+    from { background-position: 0 0; }
+    to   { background-position: 0 4px; }
+}
+
+/* Screen Flicker — brief brightness pulse on body */
+@keyframes flicker-pulse {
+    0%   { filter: brightness(1); }
+    20%  { filter: brightness(1.4); }
+    50%  { filter: brightness(0.7); }
+    80%  { filter: brightness(1.2); }
+    100% { filter: brightness(1); }
+}
+body.flicker { animation: flicker-pulse 100ms forwards; }
+
+/* Color Aberration — RGB channel split (hover / transition) */
+.aberration {
+    text-shadow:
+        -1px 0 rgba(255, 0, 0, 0.45),
+        1px  0 rgba(0, 0, 255, 0.45) !important;
+}
+
+/* Psyche / container glitch flash — horizontal jitter + hue shift */
+@keyframes glitch-flash {
+    0%   { transform: translateX(0);    filter: hue-rotate(0deg); }
+    15%  { transform: translateX(-3px); filter: hue-rotate(20deg); }
+    30%  { transform: translateX(3px);  filter: hue-rotate(-20deg); }
+    50%  { transform: translateX(-2px); filter: hue-rotate(15deg); }
+    70%  { transform: translateX(2px);  filter: hue-rotate(-10deg); }
+    85%  { transform: translateX(-1px); filter: hue-rotate(5deg); }
+    100% { transform: translateX(0);    filter: hue-rotate(0deg); }
+}
+.glitch-flash { animation: glitch-flash 300ms steps(6) forwards; }
+
+/* Reduced-motion overrides */
+@media (prefers-reduced-motion: reduce) {
+    .crt-overlay         { animation: none; }
+    body.flicker         { animation: none; filter: none; }
+    .glitch-flash        { animation: none; }
+    .aberration          { text-shadow: none !important; }
+    .screen.entering     { animation: none; opacity: 1; filter: none; }
+    .screen.exiting      { animation: none; opacity: 0; }
+}
+
 /* ── Animations ────────────────────────────────────────────── */
 @keyframes blink {
     0%, 100% { opacity: 1; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,11 +20,11 @@
     <div class="boot-ui">
         <div class="boot-logo">
             <span class="logo-bracket">[</span>
-            <span class="logo-text">IWAKURA</span>
+            <span class="logo-text" data-glitch>IWAKURA</span>
             <span class="logo-bracket">]</span>
         </div>
         <div class="boot-divider"></div>
-        <div class="boot-authorize">AUTHORIZE USER</div>
+        <div class="boot-authorize" data-glitch>AUTHORIZE USER</div>
         <div class="boot-cursor">▋</div>
         <div class="boot-status-text" id="boot-status-text">INITIALIZING...</div>
         <div class="boot-progress">
@@ -63,11 +63,11 @@
     <div class="hub-ui">
         <div class="hub-header">
             <span class="header-code green">Nda001</span>
-            <span class="header-title">THE WIRED // ACCESS POINT</span>
+            <span class="header-title" data-glitch>THE WIRED // ACCESS POINT</span>
             <span class="header-code green">Ira042</span>
         </div>
         <div class="hub-center-label">
-            <div class="center-name">L A I N</div>
+            <div class="center-name" data-glitch>L A I N</div>
             <div class="center-status" id="hub-lain-status">● PRESENT</div>
         </div>
         <div class="hub-footer">
@@ -86,7 +86,7 @@
 <div id="screen-diary" class="screen">
     <div class="screen-header">
         <button class="back-btn" data-target="hub">◀ RETURN</button>
-        <span class="screen-title">DIARY // DIRECT LINE</span>
+        <span class="screen-title" data-glitch>DIARY // DIRECT LINE</span>
         <span class="screen-code green">Lda020</span>
     </div>
     <div class="diary-messages" id="diary-messages">
@@ -114,7 +114,7 @@
 <div id="screen-status" class="screen">
     <div class="screen-header">
         <button class="back-btn" data-target="hub">◀ RETURN</button>
-        <span class="screen-title">STATUS // SYSTEM MONITOR</span>
+        <span class="screen-title" data-glitch>STATUS // SYSTEM MONITOR</span>
         <span class="screen-code green">Tda040</span>
     </div>
     <div class="status-grid" id="status-content">
@@ -130,7 +130,7 @@
 <div id="screen-memory" class="screen">
     <div class="screen-header">
         <button class="back-btn" data-target="hub">◀ RETURN</button>
-        <span class="screen-title">MEMORY // FILE ACCESS</span>
+        <span class="screen-title" data-glitch>MEMORY // FILE ACCESS</span>
         <span class="screen-code green">Wld033</span>
     </div>
     <div class="memory-layout">
@@ -149,7 +149,7 @@
 <div id="screen-psyche" class="screen">
     <div class="screen-header">
         <button class="back-btn" data-target="hub">◀ RETURN</button>
-        <span class="screen-title">PSYCHE // INTERNAL STATE</span>
+        <span class="screen-title" data-glitch>PSYCHE // INTERNAL STATE</span>
         <span class="screen-code green">Ira007</span>
     </div>
     <div class="psyche-grid" id="psyche-content">
@@ -163,6 +163,9 @@
     <input type="range" id="volume-slider" min="0" max="100" value="30">
     <span class="vol-label">VOL</span>
 </div>
+
+<!-- CRT animated scanlines overlay (managed by GlitchEffects) -->
+<div id="crt-overlay" class="crt-overlay"></div>
 
 <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
 <script src="js/data-rain.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -67,6 +67,8 @@
             doSwitch();
         } else {
             if (window.audio) window.audio.playStatic(0.15);
+            // Trigger color aberration on data-glitch elements during transition
+            if (window.glitchFX) glitchFX.applyAberrationAll('[data-glitch]', 350);
             glitchFlash(doSwitch);
         }
     }
@@ -76,6 +78,12 @@
     function runBoot() {
         const rain = new DataRain(document.getElementById('boot-rain'));
         rain.start();
+
+        // Matrix-style reveal for the boot logo
+        const logoEl = document.querySelector('.logo-text');
+        if (window.glitchFX && logoEl) {
+            glitchFX.bootReveal(logoEl, 'IWAKURA', { charDelay: 25, cycles: 5, cycleSpeed: 40 });
+        }
 
         const dotsEl     = document.getElementById('boot-progress-dots');
         const statusText = document.getElementById('boot-status-text');
@@ -328,6 +336,14 @@
     // ── Boot ──────────────────────────────────────────────────
 
     document.addEventListener('DOMContentLoaded', () => {
+        // Init glitch effects system
+        window.glitchFX = new GlitchEffects();
+        glitchFX.enableScanlines(0.08);
+        glitchFX.enableTextGlitch('[data-glitch]');
+        glitchFX.enableAberrationOnHover('[data-glitch]');
+        // Start flicker after boot sequence completes
+        setTimeout(() => glitchFX.startFlicker(), 4000);
+
         // Show boot screen (already marked active in HTML)
         runBoot();
     });

--- a/frontend/js/effects.js
+++ b/frontend/js/effects.js
@@ -1,13 +1,20 @@
 /* ── Visual Effects ───────────────────────────────────────────────────────────
-   DataRain, typewriter, screen flash
+   DataRain (offscreen-canvas optimized), typewriter, screen flash,
+   GlitchEffects (CRT scanlines, flicker, text glitch, color aberration,
+                  boot matrix reveal, psyche flash)
    ─────────────────────────────────────────────────────────────────────────── */
 
-/* ── Data Rain (Katakana + hex chars falling on canvas) ──── */
+/* ── Helpers ────────────────────────────────────────────────── */
+function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/* ── Data Rain (Katakana + hex chars falling on canvas) ──────── */
 class DataRain {
     constructor(canvas) {
-        this.canvas = canvas;
-        this.ctx = canvas.getContext('2d');
-        this.cols = [];
+        this.canvas  = canvas;
+        this.ctx     = canvas.getContext('2d');
+        this.cols    = [];
         this.running = false;
         this.frameId = null;
 
@@ -17,9 +24,49 @@ class DataRain {
             'マミムメモヤユヨラリルレロワヲン' +
             '0123456789ABCDEF▮▯░▒▓';
 
+        this._glyphCanvas = null;
+        this._glyphW      = 0;
+        this._glyphH      = 0;
+        this._glyphCount  = 0;
+
         this._resize = this._resize.bind(this);
         window.addEventListener('resize', this._resize);
         this._resize();
+        this._buildCharCache();
+    }
+
+    /* Pre-render all glyphs onto an offscreen canvas once.
+       _frame() uses drawImage + globalAlpha instead of fillText per frame,
+       avoiding per-frame font rasterization and fillStyle string allocation. */
+    _buildCharCache() {
+        const chars = this.chars;
+        const n     = chars.length;
+        const cw    = 18;   // cell width
+        const ch    = 20;   // cell height
+
+        let offCanvas;
+        try {
+            offCanvas = new OffscreenCanvas(cw * n, ch);
+        } catch (_) {
+            offCanvas = document.createElement('canvas');
+            offCanvas.width  = cw * n;
+            offCanvas.height = ch;
+        }
+
+        const gc = offCanvas.getContext('2d');
+        gc.clearRect(0, 0, cw * n, ch);
+        gc.font          = '14px "Share Tech Mono", monospace';
+        gc.textBaseline  = 'top';
+        gc.fillStyle     = 'rgb(0, 212, 170)';
+
+        for (let i = 0; i < n; i++) {
+            gc.fillText(chars[i], i * cw + 2, 3);
+        }
+
+        this._glyphCanvas = offCanvas;
+        this._glyphW      = cw;
+        this._glyphH      = ch;
+        this._glyphCount  = n;
     }
 
     _resize() {
@@ -40,28 +87,35 @@ class DataRain {
     }
 
     _frame() {
-        const { ctx, canvas, cols, chars } = this;
+        const { ctx, canvas, cols } = this;
+        const gc = this._glyphCanvas;
+        const gw = this._glyphW;
+        const gh = this._glyphH;
+        const gn = this._glyphCount;
 
         ctx.fillStyle = 'rgba(10, 10, 26, 0.055)';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-        ctx.font = '14px "Share Tech Mono", monospace';
 
         cols.forEach((col, i) => {
             const x  = i * 16 + 4;
             const y0 = col.y * 18;
 
-            // Lead char — brighter
-            const lead = chars[Math.floor(Math.random() * chars.length)];
-            ctx.fillStyle = `rgba(0, 212, 170, ${col.alpha})`;
-            ctx.fillText(lead, x, y0);
+            // Lead char — brighter, drawn via pre-rendered glyph tile
+            const leadIdx = Math.floor(Math.random() * gn);
+            ctx.globalAlpha = col.alpha;
+            ctx.drawImage(gc,
+                leadIdx * gw, 0, gw, gh,
+                x - 2, y0 - gh, gw, gh
+            );
 
             // Trail chars — fading
             for (let j = 1; j < col.len; j++) {
-                const c = chars[Math.floor(Math.random() * chars.length)];
-                const a = col.alpha * (1 - j / col.len) * 0.55;
-                ctx.fillStyle = `rgba(0, 212, 170, ${a})`;
-                ctx.fillText(c, x, y0 - j * 18);
+                const trailIdx = Math.floor(Math.random() * gn);
+                ctx.globalAlpha = col.alpha * (1 - j / col.len) * 0.55;
+                ctx.drawImage(gc,
+                    trailIdx * gw, 0, gw, gh,
+                    x - 2, y0 - j * 18 - gh, gw, gh
+                );
             }
 
             col.y += col.speed;
@@ -72,6 +126,8 @@ class DataRain {
                 col.alpha = 0.25 + Math.random() * 0.35;
             }
         });
+
+        ctx.globalAlpha = 1;
     }
 
     start() {
@@ -141,6 +197,217 @@ function glitchFlash(onMidpoint) {
     setTimeout(() => { o.remove(); }, 260);
 }
 
-window.DataRain   = DataRain;
-window.typewriter = typewriter;
-window.glitchFlash = glitchFlash;
+/* ── GlitchEffects ────────────────────────────────────────── */
+class GlitchEffects {
+    constructor(opts = {}) {
+        this._reduced = opts.reducedMotion !== undefined
+            ? opts.reducedMotion
+            : prefersReducedMotion();
+
+        this._flickerTimer  = null;
+        this._glitchTimers  = [];
+
+        // Respond to OS-level reduced motion changes dynamically
+        const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+        mq.addEventListener('change', (e) => {
+            this._reduced = e.matches;
+            if (e.matches) {
+                this.stopFlicker();
+                this.disableTextGlitch();
+            }
+        });
+    }
+
+    /* ── 1. CRT Scanlines ─────────────────────────────────── */
+
+    enableScanlines(opacity = 0.08) {
+        // Replace static scanlines (body.scanlines) with the animated overlay
+        document.body.classList.remove('scanlines');
+
+        let el = document.getElementById('crt-overlay');
+        if (!el) {
+            el = document.createElement('div');
+            el.id = 'crt-overlay';
+            el.className = 'crt-overlay';
+            document.body.appendChild(el);
+        }
+        el.style.setProperty('--scanline-opacity', String(opacity));
+        if (this._reduced) el.classList.add('no-anim');
+    }
+
+    disableScanlines() {
+        const el = document.getElementById('crt-overlay');
+        if (el) el.remove();
+        document.body.classList.add('scanlines');
+    }
+
+    /* ── 2. Screen Flicker ────────────────────────────────── */
+
+    startFlicker() {
+        if (this._reduced || this._flickerTimer) return;
+        this._scheduleFlicker();
+    }
+
+    stopFlicker() {
+        if (this._flickerTimer) {
+            clearTimeout(this._flickerTimer);
+            this._flickerTimer = null;
+        }
+    }
+
+    _scheduleFlicker() {
+        const delay = 3000 + Math.random() * 5000; // 3–8s
+        this._flickerTimer = setTimeout(() => {
+            this._flickerTimer = null;
+            document.body.classList.add('flicker');
+            setTimeout(() => document.body.classList.remove('flicker'), 120);
+            this._scheduleFlicker();
+        }, delay);
+    }
+
+    /* ── 3. Text Glitch (character corruption) ─────────────── */
+
+    enableTextGlitch(selector = '[data-glitch]') {
+        if (this._reduced) return;
+        document.querySelectorAll(selector).forEach(el => {
+            if (!el.dataset.originalText) {
+                el.dataset.originalText = el.textContent;
+            }
+            this._scheduleTextGlitch(el);
+        });
+    }
+
+    disableTextGlitch() {
+        this._glitchTimers.forEach(t => clearTimeout(t));
+        this._glitchTimers = [];
+        document.querySelectorAll('[data-original-text]').forEach(el => {
+            el.textContent = el.dataset.originalText;
+        });
+    }
+
+    _scheduleTextGlitch(el) {
+        const delay = 4000 + Math.random() * 8000; // 4–12s
+        const t = setTimeout(() => {
+            this._corruptText(el);
+            this._scheduleTextGlitch(el);
+        }, delay);
+        this._glitchTimers.push(t);
+    }
+
+    _corruptText(el) {
+        const original = el.dataset.originalText || el.textContent;
+        if (!original || original.trim() === '') return;
+
+        const glyphPool = 'アイウエオカキクケコ0123456789ABCDEF█▓▒░▮▯';
+        const len = original.length;
+        const numCorrupt = Math.max(1, Math.floor(1 + Math.random() * Math.min(3, len)));
+
+        const positions = new Set();
+        while (positions.size < numCorrupt) {
+            positions.add(Math.floor(Math.random() * len));
+        }
+
+        const corrupt = original.split('').map((c, i) =>
+            positions.has(i)
+                ? glyphPool[Math.floor(Math.random() * glyphPool.length)]
+                : c
+        ).join('');
+
+        el.textContent = corrupt;
+        setTimeout(() => { el.textContent = original; }, 80 + Math.random() * 120);
+    }
+
+    /* ── 4. Color Aberration (RGB channel split) ────────────── */
+
+    applyAberration(el, durationMs = 300) {
+        if (!el) return;
+        el.classList.add('aberration');
+        setTimeout(() => el.classList.remove('aberration'), durationMs);
+    }
+
+    enableAberrationOnHover(selector = '[data-glitch]') {
+        document.querySelectorAll(selector).forEach(el => {
+            el.addEventListener('mouseenter', () => {
+                el.classList.add('aberration');
+                setTimeout(() => el.classList.remove('aberration'), 300);
+            });
+        });
+    }
+
+    // Trigger aberration on all matching elements (e.g. during screen transitions)
+    applyAberrationAll(selector = '[data-glitch]', durationMs = 350) {
+        if (this._reduced) return;
+        document.querySelectorAll(selector).forEach(el => this.applyAberration(el, durationMs));
+    }
+
+    /* ── 5. Boot Matrix Reveal ──────────────────────────────── */
+
+    // Matrix-style character reveal: each char cycles through random glyphs
+    // before resolving to its final value (staggered by charDelay * index).
+    bootReveal(containerEl, text, opts = {}) {
+        if (this._reduced) {
+            containerEl.textContent = text;
+            if (opts.onDone) setTimeout(opts.onDone, 0);
+            return;
+        }
+
+        const {
+            charDelay  = 20,   // ms stagger between chars starting their cycle
+            cycles     = 5,    // how many random glyphs before resolving
+            cycleSpeed = 45,   // ms per random glyph during cycling
+            onDone     = null,
+        } = opts;
+
+        const glyphPool = 'アイウエオカキクケコ0123456789ABCDEF▮▯░▒▓';
+        containerEl.textContent = '';
+        const chars = text.split('');
+        let resolved = 0;
+
+        const checkDone = () => {
+            resolved++;
+            if (resolved >= chars.length) {
+                setTimeout(() => { if (onDone) onDone(); }, 150);
+            }
+        };
+
+        chars.forEach((finalChar, idx) => {
+            const span = document.createElement('span');
+            span.textContent = finalChar === ' '
+                ? '\u00A0'
+                : glyphPool[Math.floor(Math.random() * glyphPool.length)];
+            containerEl.appendChild(span);
+
+            if (finalChar === ' ') {
+                checkDone();
+                return;
+            }
+
+            setTimeout(() => {
+                let cycle = 0;
+                const iv = setInterval(() => {
+                    if (cycle < cycles) {
+                        span.textContent = glyphPool[Math.floor(Math.random() * glyphPool.length)];
+                        cycle++;
+                    } else {
+                        clearInterval(iv);
+                        span.textContent = finalChar;
+                        checkDone();
+                    }
+                }, cycleSpeed);
+            }, idx * charDelay);
+        });
+    }
+
+    /* ── 6. Psyche Screen Glitch Flash ─────────────────────── */
+
+    psycheFlash(el) {
+        if (!el) return;
+        el.classList.add('glitch-flash');
+        setTimeout(() => el.classList.remove('glitch-flash'), 300);
+    }
+}
+
+window.DataRain      = DataRain;
+window.typewriter    = typewriter;
+window.glitchFlash   = glitchFlash;
+window.GlitchEffects = GlitchEffects;

--- a/frontend/js/psyche.js
+++ b/frontend/js/psyche.js
@@ -37,8 +37,12 @@
         }
 
         _glitch() {
-            this._el.classList.add('psyche-glitch');
-            setTimeout(() => this._el.classList.remove('psyche-glitch'), 200);
+            if (window.glitchFX) {
+                window.glitchFX.psycheFlash(this._el);
+            } else {
+                this._el.classList.add('psyche-glitch');
+                setTimeout(() => this._el.classList.remove('psyche-glitch'), 200);
+            }
         }
 
         _render(data) {


### PR DESCRIPTION
## Summary

- **GlitchEffects class** in `effects.js` with full API: `enableScanlines`, `startFlicker`, `enableTextGlitch`, `applyAberrationAll`, `bootReveal`, `psycheFlash`
- **DataRain optimization**: pre-renders all katakana/hex glyphs to `OffscreenCanvas` once; hot loop uses `drawImage` + `globalAlpha` instead of per-frame `fillStyle` string allocation + `fillText`
- **CSS keyframes**: `scanline-scroll` (8s animated CRT overlay), `flicker-pulse` (body brightness pulse), `glitch-flash` (horizontal jitter + hue-rotate for psyche), `.aberration` (RGB channel split text-shadow)
- **`prefers-reduced-motion`**: all JS effects skip; CSS overrides disable animations
- **8 `data-glitch` elements** wired: boot logo, AUTHORIZE USER, L A I N, hub title, all 4 screen titles
- **Psyche screen**: `_glitch()` now delegates to `glitchFX.psycheFlash()` with existing fallback
- **Boot sequence**: matrix-style character cycling reveal for IWAKURA logo
- **Screen transitions**: color aberration fires on all `[data-glitch]` elements during nav

## Test plan

- [ ] CRT scanlines visible and subtly scrolling on all screens
- [ ] Screen flicker (brightness pulse) occurs every 3–8s
- [ ] Headers/titles show brief character corruption every 4–12s
- [ ] Color aberration (red/blue ghost) visible on screen transitions and hover
- [ ] Boot logo "IWAKURA" does matrix reveal on startup
- [ ] Psyche screen glitch-flash triggers on data refresh
- [ ] No console errors; no layout shifts
- [ ] All effects absent when OS `prefers-reduced-motion: reduce` is set

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)