### PR TITLE
feat: keyboard shortcuts — vim-style navigation + hotkeys

### DIFF
--- a/frontend/css/psx.css
+++ b/frontend/css/psx.css
@@ -171,6 +171,91 @@
     box-shadow: 0 0 6px rgba(255, 140, 0, 0.4);
 }
 
+/* ── Hotkeys help button + overlay ─────────────────────────── */
+
+/* Fixed bottom-left [ ? ] button */
+.hotkeys-btn {
+    position: fixed;
+    bottom: 14px;
+    left: 14px;
+    z-index: 10000;
+    background: transparent;
+    border: 1px solid var(--color-accent-orange);
+    color: var(--color-accent-orange);
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    padding: 3px 8px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s, box-shadow 0.2s;
+}
+.hotkeys-btn:hover {
+    opacity: 1;
+    box-shadow: 0 0 8px rgba(255, 140, 0, 0.5);
+}
+
+/* Full-screen dim backdrop */
+.hotkeys-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 10001;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.65);
+}
+.hotkeys-overlay.hidden { display: none; }
+
+/* Centered panel */
+.hotkeys-panel {
+    background: rgba(10, 10, 30, 0.97);
+    border: 1px solid var(--color-accent-orange);
+    box-shadow: 0 0 30px rgba(255, 140, 0, 0.2), inset 0 0 20px rgba(0, 0, 0, 0.5);
+    padding: 20px 28px;
+    min-width: 320px;
+    max-width: 420px;
+    font-family: 'Share Tech Mono', monospace;
+}
+
+.hotkeys-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    letter-spacing: 0.15em;
+    margin-bottom: 8px;
+}
+.hotkeys-close {
+    color: var(--color-accent-orange);
+    cursor: pointer;
+    opacity: 0.7;
+    font-size: 11px;
+}
+.hotkeys-close:hover { opacity: 1; }
+
+/* Two-column shortcuts table */
+.hotkeys-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+    font-size: 12px;
+}
+.hotkeys-table th {
+    text-align: left;
+    padding: 8px 0 4px;
+    letter-spacing: 0.12em;
+    font-weight: normal;
+}
+.hotkeys-table td {
+    padding: 3px 0;
+    color: var(--color-text);
+}
+.hotkeys-table td:first-child {
+    width: 60px;
+    font-weight: bold;
+}
+
 /* Inline purge confirmation prompt */
 .purge-prompt {
     padding: 10px 0;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -168,6 +168,40 @@
 <!-- CRT animated scanlines overlay (managed by GlitchEffects) -->
 <div id="crt-overlay" class="crt-overlay"></div>
 
+<!-- ── HOTKEYS HELP OVERLAY ───────────────────────────────── -->
+<button id="hotkeys-btn" class="hotkeys-btn" title="Keyboard shortcuts">[ ? ]</button>
+
+<div id="hotkeys-help" class="hotkeys-overlay hidden">
+    <div class="hotkeys-panel">
+        <div class="hotkeys-header">
+            <span class="orange">KEYBOARD SHORTCUTS</span>
+            <span class="hotkeys-close" id="hotkeys-close">[ × ]</span>
+        </div>
+        <div class="hr-orange"></div>
+        <table class="hotkeys-table">
+            <thead>
+                <tr><th class="cyan" colspan="2">GLOBAL</th></tr>
+            </thead>
+            <tbody>
+                <tr><td class="green">1</td><td>Go to DIARY</td></tr>
+                <tr><td class="green">2</td><td>Go to STATUS</td></tr>
+                <tr><td class="green">3</td><td>Go to MEMORY</td></tr>
+                <tr><td class="green">4</td><td>Go to PSYCHE</td></tr>
+                <tr><td class="green">Esc</td><td>Return to HUB</td></tr>
+                <tr><td class="green">m</td><td>Toggle mute</td></tr>
+                <tr><td class="green">?</td><td>Show / hide this panel</td></tr>
+            </tbody>
+            <thead>
+                <tr><th class="cyan" colspan="2">DIARY (when not in input)</th></tr>
+            </thead>
+            <tbody>
+                <tr><td class="green">/</td><td>Focus message input</td></tr>
+                <tr><td class="green">r</td><td>Scroll to bottom</td></tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
 <script src="js/data-rain.js"></script>
 <script src="js/audio.js"></script>
@@ -177,6 +211,7 @@
 <script src="js/psyche.js"></script>
 <script src="js/memory.js"></script>
 <script src="js/status.js"></script>
+<script src="js/hotkeys.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -281,14 +281,7 @@
         });
     });
 
-    // ── Global ESC → return to hub ────────────────────────────
-
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && currentScreen !== 'boot' && currentScreen !== 'hub') {
-            if (window.audio) window.audio.playClick();
-            showScreen('hub');
-        }
-    });
+    // ESC and screen shortcuts are handled by hotkeys.js
 
     // ── Status refresh ────────────────────────────────────────
 
@@ -358,10 +351,26 @@
         // Start flicker after boot sequence completes
         setTimeout(() => glitchFX.startFlicker(), 4000);
 
+        // Init hotkeys
+        window.hotkeys = new IwakuraHotkeys(
+            showScreen,
+            () => window.audio ? window.audio.toggleMute() : false
+        );
+        window.hotkeys.init();
+
+        // Wire up close button in hotkey overlay
+        const hkClose = document.getElementById('hotkeys-close');
+        if (hkClose) hkClose.addEventListener('click', () => window.hotkeys._hideHelp());
+
         // Show boot screen (already marked active in HTML)
         runBoot();
     });
 
-    // Expose for debugging
-    window.iwakura = { showScreen, loadStatus, initMemory, loadPsyche, getPsyche: () => psyche };
+    // Expose for debugging and hotkeys
+    window.iwakura = {
+        showScreen,
+        loadStatus, initMemory, loadPsyche,
+        getPsyche: () => psyche,
+        currentScreen: () => currentScreen,
+    };
 })();

--- a/frontend/js/hotkeys.js
+++ b/frontend/js/hotkeys.js
@@ -1,0 +1,114 @@
+/* ── Iwakura Platform — Keyboard Shortcuts ─────────────────────────────────
+   Vim-style hotkeys: screen nav, mute, diary focus.
+   Single keydown listener; disabled when typing in input/textarea.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+class IwakuraHotkeys {
+    constructor(showScreenFn, toggleMuteFn) {
+        this._showScreen  = showScreenFn;
+        this._toggleMute  = toggleMuteFn;
+        this._helpVisible = false;
+    }
+
+    init() {
+        document.addEventListener('keydown', this._onKey.bind(this));
+
+        // Help button
+        const btn = document.getElementById('hotkeys-btn');
+        if (btn) btn.addEventListener('click', () => this._toggleHelp());
+
+        // Close overlay on outside click
+        const overlay = document.getElementById('hotkeys-help');
+        if (overlay) {
+            overlay.addEventListener('click', (e) => {
+                if (e.target === overlay) this._hideHelp();
+            });
+        }
+    }
+
+    _isTyping() {
+        const tag = document.activeElement && document.activeElement.tagName;
+        return tag === 'INPUT' || tag === 'TEXTAREA';
+    }
+
+    _currentScreen() {
+        return window.iwakura && window.iwakura.currentScreen
+            ? window.iwakura.currentScreen()
+            : null;
+    }
+
+    _onKey(e) {
+        // Close help overlay on Escape regardless of typing state
+        if (e.key === 'Escape' && this._helpVisible) {
+            this._hideHelp();
+            return;
+        }
+
+        if (this._isTyping()) return;
+
+        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche' };
+
+        if (screenMap[e.key]) {
+            if (window.audio) window.audio.playClick();
+            this._showScreen(screenMap[e.key]);
+            return;
+        }
+
+        if (e.key === 'Escape') {
+            const cur = this._currentScreen();
+            if (cur && cur !== 'boot' && cur !== 'hub') {
+                if (window.audio) window.audio.playClick();
+                this._showScreen('hub');
+            }
+            return;
+        }
+
+        if (e.key === 'm') {
+            if (this._toggleMute) {
+                const muted = this._toggleMute();
+                const icon = document.getElementById('vol-icon');
+                if (icon) {
+                    icon.classList.toggle('muted', muted);
+                    icon.textContent = muted ? '✕' : '♪';
+                }
+            }
+            return;
+        }
+
+        // Diary-only shortcuts
+        if (this._currentScreen() === 'diary') {
+            if (e.key === '/') {
+                e.preventDefault();
+                const input = document.getElementById('diary-input');
+                if (input) input.focus();
+                return;
+            }
+            if (e.key === 'r') {
+                const msgs = document.getElementById('diary-messages');
+                if (msgs) msgs.scrollTop = msgs.scrollHeight;
+                return;
+            }
+        }
+
+        if (e.key === '?') {
+            this._toggleHelp();
+            return;
+        }
+    }
+
+    _toggleHelp() {
+        if (this._helpVisible) this._hideHelp(); else this._showHelp();
+    }
+
+    _showHelp() {
+        const overlay = document.getElementById('hotkeys-help');
+        if (overlay) overlay.classList.remove('hidden');
+        this._helpVisible = true;
+    }
+
+    _hideHelp() {
+        const overlay = document.getElementById('hotkeys-help');
+        if (overlay) overlay.classList.add('hidden');
+        this._helpVisible = false;
+    }
+}


### PR DESCRIPTION
## Summary

- New `hotkeys.js` module with a single `keydown` listener (`IwakuraHotkeys` class)
- Screen nav via `1`–`4`, `Escape` → hub, `m` toggle mute, `/` focus diary input, `r` scroll to bottom
- `?` opens a PSX-styled hotkey cheat sheet overlay (dark panel, orange header, green key labels)
- `[ ? ]` button fixed at bottom-left; overlay dismisses on outside-click or Escape
- Shortcuts disabled when user is typing in any `input`/`textarea`
- Removed duplicate Escape handler from `app.js`; exposed `currentScreen()` getter on `window.iwakura`

## Test plan
- [ ] Press `1`–`4` from hub — navigates to correct screen with glitch transition
- [ ] Press `Esc` from any non-hub screen — returns to hub
- [ ] Press `m` — toggles mute, vol icon updates
- [ ] In diary, press `/` — focuses message input
- [ ] In diary, press `r` — scrolls to bottom of messages
- [ ] Press `?` — cheat sheet overlay appears
- [ ] Click outside overlay or press `Esc` — overlay closes
- [ ] Type in diary input — no hotkeys fire while typing
- [ ] `[ ? ]` button visible in bottom-left on all screens

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)