### PR TITLE
feat: PSYCHE mood indicator — derive Lain emotional state from activity patterns

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -146,6 +146,44 @@ async def api_memory_file(filename: str):
     return JSONResponse({"name": filename, "content": content, "rendered": rendered})
 
 
+def _derive_mood(state: dict, initiative: dict, think: dict, think_delta: dict) -> dict:
+    signals = []
+    score = 0
+
+    active_tasks = [t for t in state.get("tasks", []) if isinstance(t, dict) and t.get("status") == "in_progress"]
+    if active_tasks:
+        score += 30
+        signals.append(f"{len(active_tasks)} task(s) active")
+
+    if think_delta and think_delta.get("cycles", 0) > 0:
+        score += 25
+        signals.append(f"think cycles: {think_delta['cycles']}")
+
+    msgs_today = initiative.get("messages_sent_today", 0)
+    if msgs_today > 3:
+        score += 20
+        signals.append(f"{msgs_today} messages sent today")
+    elif msgs_today > 0:
+        score += 10
+        signals.append(f"{msgs_today} message(s) today")
+
+    failed = [t for t in state.get("tasks", []) if isinstance(t, dict) and t.get("status") == "failed"]
+    if failed:
+        score -= 20
+        signals.append(f"{len(failed)} failed task(s)")
+
+    if score >= 60:
+        return {"label": "FOCUSED", "intensity": min(score, 100), "signals": signals, "color": "#ff8c00"}
+    elif score >= 35:
+        return {"label": "RESONANT", "intensity": score, "signals": signals, "color": "#00ff88"}
+    elif score >= 15:
+        return {"label": "DEEP", "intensity": score, "signals": signals, "color": "#00d4aa"}
+    elif failed:
+        return {"label": "ALERT", "intensity": max(30, abs(score)), "signals": signals, "color": "#ff4444"}
+    else:
+        return {"label": "IDLE", "intensity": 10, "signals": signals or ["no recent activity"], "color": "#8b7cc8"}
+
+
 @app.get("/api/psyche")
 async def api_psyche():
     data = {}
@@ -196,6 +234,14 @@ async def api_psyche():
 
     # session info
     data["session_id"] = gateway.get_current_session_id()
+
+    # mood indicator
+    data["mood"] = _derive_mood(
+        data.get("state", {}),
+        data.get("initiative", {}),
+        data.get("think", {}),
+        data.get("think_delta", {}),
+    )
 
     return JSONResponse(data)
 

--- a/frontend/css/psx.css
+++ b/frontend/css/psx.css
@@ -281,3 +281,55 @@
     outline: none;
     letter-spacing: 0.12em;
 }
+
+/* ── Mood Indicator ──────────────────────────────────────────────────────── */
+.mood-indicator {
+    border: 1px solid var(--mood-color, #ff8c00);
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    background: rgba(0,0,0,0.4);
+}
+.mood-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.4rem;
+}
+.mood-label {
+    font-family: 'VT323', monospace;
+    font-size: 1.4rem;
+    letter-spacing: 2px;
+}
+.mood-intensity {
+    color: #888;
+    font-size: 0.75rem;
+}
+.mood-bar {
+    font-family: monospace;
+    color: var(--mood-color, #ff8c00);
+    letter-spacing: 2px;
+    margin-bottom: 0.4rem;
+}
+.mood-signals {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+.mood-signals span {
+    font-size: 0.7rem;
+    color: #8b7cc8;
+    background: rgba(139,124,200,0.1);
+    padding: 0.1rem 0.4rem;
+}
+.mood-pulse {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--mood-color, #ff8c00);
+    animation: mood-pulse 1.5s ease-in-out infinite;
+    flex-shrink: 0;
+}
+@keyframes mood-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.3; transform: scale(0.6); }
+}

--- a/frontend/js/psyche.js
+++ b/frontend/js/psyche.js
@@ -45,6 +45,24 @@
             }
         }
 
+        _renderMood(mood) {
+            if (!mood) return '';
+            const { label, intensity, signals, color } = mood;
+            const bars = Math.round(intensity / 10);
+            const barHtml = '█'.repeat(bars) + '░'.repeat(10 - bars);
+            return `
+                <div class="mood-indicator" style="--mood-color:${esc(color)}">
+                    <div class="mood-header">
+                        <span class="mood-pulse"></span>
+                        <span class="mood-label" style="color:${esc(color)}">${esc(label)}</span>
+                        <span class="mood-intensity">${esc(String(intensity))}%</span>
+                    </div>
+                    <div class="mood-bar">${barHtml}</div>
+                    <div class="mood-signals">${(signals || []).map(s => `<span>${esc(s)}</span>`).join('')}</div>
+                </div>
+            `;
+        }
+
         _render(data) {
             const {
                 state = {},
@@ -53,9 +71,13 @@
                 session_id,
                 soul_excerpt = '',
                 heartbeat = '',
+                mood = null,
             } = data;
 
             let html = '';
+
+            // ── Mood Indicator ──
+            html += this._renderMood(mood);
 
             // ── Header bar ──
             const ts = new Date().toISOString().slice(11, 19) + 'Z';


### PR DESCRIPTION
## Summary
- Extends `/api/psyche` with a `_derive_mood()` helper that analyzes active tasks, think cycles, initiative message counts, and failed tasks to produce a mood object (`label`, `intensity`, `signals`, `color`)
- Five distinct mood states: **FOCUSED** (orange), **RESONANT** (green), **DEEP** (cyan), **IDLE** (purple), **ALERT** (red)
- Adds `_renderMood()` to `frontend/js/psyche.js` — renders a PSX-styled widget with pulse animation, intensity bar, and signal tags, prepended to the PSYCHE screen
- Adds `.mood-indicator`, `.mood-pulse`, `@keyframes mood-pulse`, and related styles to `frontend/css/psx.css`

## Test plan
- [ ] `GET /api/psyche` returns `mood` object with `label`, `intensity`, `signals`, `color` fields
- [ ] PSYCHE screen displays mood widget at top with animated pulse dot
- [ ] Intensity bar renders as `█░` chars scaled to intensity
- [ ] Signal tags appear below the bar
- [ ] 30s auto-refresh cycle updates mood widget
- [ ] No regressions in existing PSYCHE sections (tasks, PRs, initiative, think state, heartbeat, soul)

Closes #36