### PR TITLE
feat: diary auto-scroll + unread badge + typing indicator

### DIFF
--- a/frontend/css/psx.css
+++ b/frontend/css/psx.css
@@ -333,3 +333,30 @@
     0%, 100% { opacity: 1; transform: scale(1); }
     50% { opacity: 0.3; transform: scale(0.6); }
 }
+
+/* ── Typing indicator ────────────────────────────────────── */
+.typing-indicator .typing-dots span {
+    animation: blink 1.2s infinite;
+    color: #00d4aa;
+}
+.typing-indicator .typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+.typing-indicator .typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes blink { 0%, 80%, 100% { opacity: 0; } 40% { opacity: 1; } }
+
+/* ── Unread badge ─────────────────────────────────────────── */
+.unread-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #ff8c00;
+    color: #000;
+    font-size: 0.55rem;
+    font-weight: bold;
+    min-width: 14px;
+    height: 14px;
+    border-radius: 7px;
+    padding: 0 2px;
+    vertical-align: middle;
+    margin-left: 4px;
+    font-family: 'VT323', monospace;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,7 +44,7 @@
     <div id="hub-nav-labels">
         <div class="nav-label-item" data-target="diary">
             <div class="nav-label-code">Lda020</div>
-            <div class="nav-label-name">DIARY</div>
+            <div class="nav-label-name">DIARY <span id="diary-unread-badge" class="unread-badge" style="display:none"></span></div>
         </div>
         <div class="nav-label-item" data-target="status">
             <div class="nav-label-code">Tda040</div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -61,6 +61,11 @@
 
             // Stop status auto-refresh when leaving status
             if (name !== 'status' && statusDash) statusDash.stop();
+
+            // Unread badge: mark diary active/inactive
+            if (chat) {
+                chat.setActive(name === 'diary');
+            }
         };
 
         if (skipGlitch) {
@@ -372,5 +377,7 @@
         loadStatus, initMemory, loadPsyche,
         getPsyche: () => psyche,
         currentScreen: () => currentScreen,
+        clearDiaryUnread: () => { if (chat) chat.clearUnread(); },
+        setDiaryActive: (v) => { if (chat) chat.setActive(v); },
     };
 })();

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -13,6 +13,7 @@ class IwakuraChat {
         this._reconnTimer  = null;
         this._pingInterval = null;
         this._thinkEl      = null;
+        this._typingEl     = null;
         this.container     = null;
 
         // Streaming state — active Lain bubble being built
@@ -20,6 +21,13 @@ class IwakuraChat {
         this._streamBuf    = '';    // accumulated text so far
         this._streamCode   = null;  // fileCode for current stream
         this._streamTime   = null;  // timestamp for current stream
+
+        // Auto-scroll state
+        this._userScrolledUp = false;
+
+        // Unread badge state
+        this._unreadCount    = 0;
+        this._isDiaryActive  = false;
 
         // Callbacks
         this.onStatusChange  = null;  // fn(bool connected)
@@ -32,6 +40,14 @@ class IwakuraChat {
         this.container = container;
         this._restoreHistory();
         this._connect();
+
+        // Auto-scroll: track when user scrolls up
+        if (container) {
+            container.addEventListener('scroll', () => {
+                const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
+                this._userScrolledUp = !atBottom;
+            });
+        }
     }
 
     clearDiary() {
@@ -41,9 +57,23 @@ class IwakuraChat {
     sendMessage(text) {
         text = (text || '').trim();
         if (!text || !this.connected) return false;
+        this._userScrolledUp = false;  // user wants to see response
         this._addUserMsg(text);
         this._send({ type: 'message', text });
+        this._showTyping();
         return true;
+    }
+
+    // ── Unread badge API (called by app.js) ───────────────────
+
+    setActive(isActive) {
+        this._isDiaryActive = isActive;
+        if (isActive) this.clearUnread();
+    }
+
+    clearUnread() {
+        this._unreadCount = 0;
+        this._updateBadge();
     }
 
     resetSession() {
@@ -126,11 +156,14 @@ class IwakuraChat {
 
             case 'token':
                 this._hideThinking();
+                this._hideTyping();
                 this._appendToken(msg);
                 break;
 
             case 'done':
+                this._hideTyping();
                 this._finalizeStream(msg);
+                this._incrementUnread();
                 if (this.onSessionChange) this.onSessionChange(msg.sessionId);
                 if (window.audio) window.audio.playBeep();
                 break;
@@ -138,13 +171,16 @@ class IwakuraChat {
             case 'response':
                 // Legacy fallback — backend may still send this
                 this._hideThinking();
+                this._hideTyping();
                 this._addLainMsg(msg);
+                this._incrementUnread();
                 if (this.onSessionChange) this.onSessionChange(msg.sessionId);
                 if (window.audio) window.audio.playBeep();
                 break;
 
             case 'error':
                 this._hideThinking();
+                this._hideTyping();
                 this._finalizeStream(null);
                 this._addErrorMsg(msg.text || 'UNKNOWN ERROR');
                 break;
@@ -321,6 +357,31 @@ class IwakuraChat {
         if (this._thinkEl) { this._thinkEl.remove(); this._thinkEl = null; }
     }
 
+    _showTyping() {
+        if (this._typingEl) return;
+        this._typingEl = document.createElement('div');
+        this._typingEl.className = 'message lain-message typing-indicator';
+        this._typingEl.innerHTML = '<span class="typing-dots"><span>.</span><span>.</span><span>.</span></span>';
+        this._append(this._typingEl);
+    }
+
+    _hideTyping() {
+        if (this._typingEl) { this._typingEl.remove(); this._typingEl = null; }
+    }
+
+    _incrementUnread() {
+        if (this._isDiaryActive) return;
+        this._unreadCount++;
+        this._updateBadge();
+    }
+
+    _updateBadge() {
+        const badge = document.getElementById('diary-unread-badge');
+        if (!badge) return;
+        badge.textContent = this._unreadCount > 0 ? String(this._unreadCount) : '';
+        badge.style.display = this._unreadCount > 0 ? 'flex' : 'none';
+    }
+
     _append(el) {
         if (this.container) {
             this.container.appendChild(el);
@@ -329,7 +390,10 @@ class IwakuraChat {
     }
 
     _scrollBottom() {
-        if (this.container) this.container.scrollTop = this.container.scrollHeight;
+        if (!this.container) return;
+        if (!this._userScrolledUp) {
+            this.container.scrollTop = this.container.scrollHeight;
+        }
     }
 
     // ── History persistence ───────────────────────────────────

--- a/frontend/js/diary.js
+++ b/frontend/js/diary.js
@@ -24,6 +24,10 @@
     let reconnTimer   = null;
     let pingInterval  = null;
     let thinkEl       = null;
+    let typingEl      = null;
+
+    // ── Auto-scroll state ─────────────────────────────────────
+    let userScrolledUp = false;
 
     // ── Connect ───────────────────────────────────────────────
     function connect() {
@@ -97,6 +101,27 @@
         if (sendBtn)   sendBtn.disabled    = !isConnected;
     }
 
+    // ── Scroll listener for auto-scroll ───────────────────────
+    if (messagesEl) {
+        messagesEl.addEventListener('scroll', () => {
+            const atBottom = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight < 100;
+            userScrolledUp = !atBottom;
+        });
+    }
+
+    // ── Typing indicator ──────────────────────────────────────
+    function showTyping() {
+        if (typingEl) return;
+        typingEl = document.createElement('div');
+        typingEl.className = 'message lain-message typing-indicator';
+        typingEl.innerHTML = '<span class="typing-dots"><span>.</span><span>.</span><span>.</span></span>';
+        append(typingEl);
+    }
+
+    function hideTyping() {
+        if (typingEl) { typingEl.remove(); typingEl = null; }
+    }
+
     // ── Message handling ──────────────────────────────────────
     function handleMsg(msg) {
         switch (msg.type) {
@@ -106,6 +131,7 @@
 
             case 'response':
                 hideThinking();
+                hideTyping();
                 addLainMsg(msg);
                 if (msg.sessionId) {
                     const short = msg.sessionId.slice(0, 16) + '...';
@@ -115,6 +141,7 @@
 
             case 'error':
                 hideThinking();
+                hideTyping();
                 addMsg('error', msg.text || 'SIGNAL LOST');
                 break;
 
@@ -213,7 +240,9 @@
     }
 
     function scrollBottom() {
-        if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+        if (messagesEl && !userScrolledUp) {
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
     }
 
     // ── Typewriter ────────────────────────────────────────────
@@ -247,10 +276,12 @@
     function doSend() {
         const text = (inputEl.value || '').trim();
         if (!text || !connected) return;
+        userScrolledUp = false;  // user wants to see response
         addUserMsg(text);
         send({ type: 'message', text });
         inputEl.value = '';
         if (tagsEl) tagsEl.innerHTML = '';
+        showTyping();
     }
 
     // ── Tag preview ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Auto-scroll: tracks user scroll position and only scrolls to bottom when not manually scrolled up; resets when user sends a message
- Typing indicator: animated cyan dots (`...`) shown immediately after sending, hidden when response or error arrives
- Unread badge: orange counter on the DIARY hub nav label increments when Lain responds while the diary screen is not active; clears on entry

## Changes
- `chat.js`: `_userScrolledUp` flag + scroll listener, `_showTyping`/`_hideTyping`, unread counter + badge update, `setActive`/`clearUnread` public API
- `diary.js` (standalone): same auto-scroll and typing indicator logic
- `app.js`: calls `chat.setActive()` on screen transitions, exposes `clearDiaryUnread`/`setDiaryActive` on `window.iwakura`
- `index.html`: adds `<span id="diary-unread-badge">` to DIARY nav label
- `psx.css`: typing indicator blink animation + unread badge styles

## Test plan
- [ ] Open hub, send a message from another tab/wait for Lain response → badge appears on DIARY label
- [ ] Navigate to DIARY → badge clears
- [ ] Navigate away, return → badge resets
- [ ] Send message → animated `...` typing indicator appears, disappears when response arrives
- [ ] Scroll up in diary, new message arrives → no auto-scroll (stays where you are)
- [ ] Send a new message → auto-scroll resumes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)