### PR TITLE
feat: memory search/filter — inline filename filter + content search

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -131,6 +131,32 @@ async def api_memory_list():
     return JSONResponse({"files": files})
 
 
+@app.get("/api/memory/search")
+async def api_memory_search(q: str = ""):
+    if not q or len(q) < 2:
+        return JSONResponse({"results": []})
+    query = q.lower()
+    results = []
+    if LAIN_MEMORY.exists():
+        for f in sorted(LAIN_MEMORY.iterdir()):
+            if not f.is_file():
+                continue
+            try:
+                content = f.read_text(errors="replace")
+                count = content.lower().count(query)
+                if count == 0:
+                    continue
+                idx = content.lower().find(query)
+                start = max(0, idx - 60)
+                end = min(len(content), idx + len(query) + 80)
+                excerpt = content[start:end].replace('\n', ' ').strip()
+                results.append({"name": f.name, "excerpt": excerpt, "match_count": count})
+            except Exception:
+                pass
+    results.sort(key=lambda x: x["match_count"], reverse=True)
+    return JSONResponse({"results": results[:8], "query": q})
+
+
 @app.get("/api/memory/{filename}")
 async def api_memory_file(filename: str):
     # Sanitize

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -583,6 +583,38 @@ body::after {
     border: 1px solid rgba(210,185,128,0.45);
     color: var(--beige); padding: 0 3px;
 }
+.mem-search-input {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    background: rgba(255,140,0,0.05);
+    border: 1px solid rgba(255,140,0,0.2);
+    border-radius: 2px;
+    color: var(--orange);
+    padding: 3px 8px;
+    outline: none;
+    width: 160px;
+    transition: border-color 0.2s;
+}
+.mem-search-input:focus { border-color: var(--orange); }
+.mem-search-badge {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--orange);
+    margin-left: 8px;
+}
+mark.mem-kw-match {
+    background: rgba(255,140,0,0.25);
+    color: var(--white);
+    font-style: normal;
+}
+.mem-excerpt {
+    font-size: 9px;
+    color: var(--dim);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 
 /* ── Psyche Screen ─────────────────────────────────────────── */
 .psyche-grid {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,6 +133,8 @@
         <button class="back-btn" data-target="hub">◀ RETURN</button>
         <span class="screen-title" data-glitch>MEMORY // FILE ACCESS</span>
         <span class="screen-code green">Wld033</span>
+        <input type="text" id="mem-search" class="mem-search-input" placeholder="SEARCH MEMORY..." autocomplete="off" spellcheck="false">
+        <span id="mem-search-badge" class="mem-search-badge" style="display:none"></span>
     </div>
     <div class="memory-layout">
         <div class="memory-sidebar" id="memory-list">

--- a/frontend/js/hotkeys.js
+++ b/frontend/js/hotkeys.js
@@ -90,6 +90,16 @@ class IwakuraHotkeys {
             }
         }
 
+        // Memory-only shortcuts
+        if (this._currentScreen() === 'memory') {
+            if (e.key === '/') {
+                e.preventDefault();
+                const input = document.getElementById('mem-search');
+                if (input) input.focus();
+                return;
+            }
+        }
+
         if (e.key === '?') {
             this._toggleHelp();
             return;

--- a/frontend/js/memory.js
+++ b/frontend/js/memory.js
@@ -8,11 +8,12 @@
 
     class IwakuraMemory {
         constructor() {
-            this._files      = [];
-            this._selected   = -1;
-            this._viewing    = false; // true when a file is open in viewer
-            this._active     = false;
-            this._keyHandler = null;
+            this._files       = [];
+            this._selected    = -1;
+            this._viewing     = false; // true when a file is open in viewer
+            this._active      = false;
+            this._keyHandler  = null;
+            this._searchQuery = null;
         }
 
         /* Called by app.js when memory screen becomes active */
@@ -26,6 +27,9 @@
         stop() {
             this._active = false;
             this._unbindKeys();
+            // Reset search binding flag so it rebinds on next init
+            const input = document.getElementById('mem-search');
+            if (input) input._bound = false;
         }
 
         // ── Internal ──────────────────────────────────────────
@@ -53,9 +57,134 @@
 
                 this._renderList(listEl, viewerEl);
                 this._highlight(0); // pre-select first item without opening
+                this._bindSearch();
             } catch (e) {
                 listEl.innerHTML = '<div class="screen-loading red">ERROR LOADING FILES</div>';
             }
+        }
+
+        _bindSearch() {
+            const input = document.getElementById('mem-search');
+            if (!input || input._bound) return;
+            input._bound = true;
+
+            input.addEventListener('input', () => {
+                const val = input.value.trim();
+                if (val) {
+                    this._filterList(val);
+                } else {
+                    this._clearSearch();
+                }
+            });
+
+            input.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    const val = input.value.trim();
+                    if (val) this._contentSearch(val);
+                } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this._clearSearch();
+                    input.blur();
+                }
+            });
+        }
+
+        _filterList(q) {
+            const listEl = document.getElementById('memory-list');
+            if (!listEl) return;
+            const filtered = this._files.filter(f => f.name.toLowerCase().includes(q.toLowerCase()));
+            listEl.innerHTML = '';
+            if (!filtered.length) {
+                listEl.innerHTML = '<div class="screen-loading dim">NO MATCHES</div>';
+                this._setBadge(`[0 FILES]`, false);
+                return;
+            }
+            filtered.forEach((f, i) => {
+                const item = document.createElement('div');
+                item.className = 'mem-file';
+                item.dataset.idx = i;
+                const code   = memCode(this._files.indexOf(f));
+                const sizeKB = f.size ? (f.size / 1024).toFixed(1) + ' KB' : '--';
+                const modDate = f.modified
+                    ? new Date(f.modified * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' })
+                    : '--';
+                item.innerHTML = `
+                    <div class="mem-file-name">${esc(f.name)}</div>
+                    <div class="mem-file-meta">
+                        <span class="orange">${code}</span>
+                        <span>${esc(sizeKB)} · ${esc(f.type || '')}</span>
+                        <span class="dim">${esc(modDate)}</span>
+                    </div>
+                `;
+                item.addEventListener('click', () => {
+                    const realIdx = this._files.indexOf(f);
+                    this._open(realIdx);
+                });
+                listEl.appendChild(item);
+            });
+            this._setBadge(`[${filtered.length} FILES]`, false);
+        }
+
+        async _contentSearch(q) {
+            const listEl = document.getElementById('memory-list');
+            if (!listEl) return;
+            this._searchQuery = q;
+            listEl.innerHTML = '<div class="screen-loading purple">SEARCHING<span class="loading-dots"></span></div>';
+            try {
+                const res  = await fetch('/api/memory/search?q=' + encodeURIComponent(q));
+                const data = await res.json();
+                const results = data.results || [];
+                listEl.innerHTML = '';
+                if (!results.length) {
+                    listEl.innerHTML = '<div class="screen-loading dim">NO CONTENT MATCHES</div>';
+                    this._setBadge('[0 MATCHES]', true);
+                    return;
+                }
+                results.forEach((r, i) => {
+                    const item = document.createElement('div');
+                    item.className = 'mem-file';
+                    item.dataset.idx = i;
+                    item.innerHTML = `
+                        <div class="mem-file-name">${esc(r.name)}</div>
+                        <div class="mem-excerpt">${esc(r.excerpt)}</div>
+                        <div class="mem-file-meta">
+                            <span class="orange">${r.match_count} match${r.match_count !== 1 ? 'es' : ''}</span>
+                        </div>
+                    `;
+                    item.addEventListener('click', () => {
+                        const realIdx = this._files.findIndex(f => f.name === r.name);
+                        if (realIdx >= 0) this._open(realIdx);
+                    });
+                    listEl.appendChild(item);
+                });
+                this._setBadge(`[${results.length} MATCHES]`, true);
+            } catch (e) {
+                listEl.innerHTML = '<div class="screen-loading red">SEARCH ERROR</div>';
+            }
+        }
+
+        _clearSearch() {
+            const input = document.getElementById('mem-search');
+            if (input) input.value = '';
+            this._searchQuery = null;
+            this._setBadge('', false);
+            const badge = document.getElementById('mem-search-badge');
+            if (badge) badge.style.display = 'none';
+            const listEl   = document.getElementById('memory-list');
+            const viewerEl = document.getElementById('memory-viewer');
+            if (listEl) this._renderList(listEl, viewerEl);
+            this._highlight(0);
+        }
+
+        _setBadge(text, orange) {
+            const badge = document.getElementById('mem-search-badge');
+            if (!badge) return;
+            if (!text) { badge.style.display = 'none'; return; }
+            badge.textContent = text;
+            badge.style.display = '';
+            badge.style.color = orange ? 'var(--orange)' : 'var(--green)';
         }
 
         _renderList(listEl, viewerEl) {
@@ -117,22 +246,23 @@
 
             const f    = this._files[idx];
             const code = memCode(idx);
-            this._loadFile(f.name, document.getElementById('memory-viewer'), code);
+            this._loadFile(f.name, document.getElementById('memory-viewer'), code, this._searchQuery);
         }
 
-        async _loadFile(name, viewerEl, code) {
+        async _loadFile(name, viewerEl, code, searchQuery) {
             if (!viewerEl) return;
             viewerEl.innerHTML = '<div class="screen-loading purple">ACCESSING<span class="loading-dots"></span></div>';
             try {
                 const res  = await fetch('/api/memory/' + encodeURIComponent(name));
                 if (!res.ok) throw new Error('HTTP ' + res.status);
                 const data = await res.json();
+                const rendered = renderMemContent(data.content || '', name, searchQuery);
                 viewerEl.innerHTML = `
                     <div class="mem-view-hdr">
                         <span class="mem-view-title">${esc(name)}</span>
                         <span class="mem-view-code">${code}</span>
                     </div>
-                    <div class="mem-view-body">${renderMemContent(data.content || '', name)}</div>
+                    <div class="mem-view-body">${rendered}</div>
                 `;
             } catch (e) {
                 viewerEl.innerHTML = `
@@ -198,9 +328,10 @@
         return prefixes[i % prefixes.length] + String(i * 7 + 14).padStart(3, '0');
     }
 
-    function renderMemContent(content, name) {
+    function renderMemContent(content, name, searchQuery) {
+        let html;
         if (name.endsWith('.md')) {
-            return content
+            html = content
                 .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
                 .replace(/^# (.+)$/gm,   '<h1>$1</h1>')
                 .replace(/^## (.+)$/gm,  '<h2>$1</h2>')
@@ -211,8 +342,14 @@
                     /\b([A-Z][a-z]+(?:\s[A-Z][a-z]+){1,3})\b/g,
                     '<span class="mem-kw">$1</span>'
                 );
+        } else {
+            html = esc(content);
         }
-        return esc(content);
+        if (searchQuery && searchQuery.length >= 2) {
+            const escaped = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            html = html.replace(new RegExp(escaped, 'gi'), m => `<mark class="mem-kw-match">${m}</mark>`);
+        }
+        return html;
     }
 
     function esc(s) {


### PR DESCRIPTION
## Summary

- **Filename filter**: typing in the search input live-filters the sidebar by filename
- **Content search**: pressing Enter fetches `/api/memory/search?q=` and shows excerpts with match counts
- **Keyword highlight**: opening any file while a search is active wraps matching text in `<mark class="mem-kw-match">` (orange glow)
- **Esc** clears search and restores the full file list
- **`/` hotkey** focuses the search input when on the MEMORY screen

## Test plan

- [ ] Open MEMORY screen, type partial filename → list filters live, badge shows `[N FILES]`
- [ ] Type a word and press Enter → content search runs, shows excerpts + match count badges, badge shows `[N MATCHES]` in orange
- [ ] Click a result → file opens with search term highlighted in viewer
- [ ] Press Esc → input clears, full list restored
- [ ] Press `/` from anywhere on memory screen (not typing) → search input focuses

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)