### PR TITLE
feat: STATUS — fix OpenClaw crons + compact idle AO sessions

### DIFF
--- a/backend/status.py
+++ b/backend/status.py
@@ -78,24 +78,61 @@ async def get_ao_sessions() -> list[dict]:
 
 
 async def get_openclaw_crons() -> list[dict]:
-    """Fetch cron jobs from the OpenClaw gateway API."""
-    try:
-        import httpx
-        async with httpx.AsyncClient(timeout=3.0) as client:
-            resp = await client.get("http://127.0.0.1:18789/api/crons")
-            resp.raise_for_status()
-            data = resp.json()
-            jobs = []
-            for item in (data if isinstance(data, list) else data.get("jobs", [])):
-                jobs.append({
+    """Fetch cron jobs via openclaw CLI (gateway /api/crons returns 404)."""
+    # Try openclaw cron list --json first
+    raw = await _run(["openclaw", "cron", "list", "--json"])
+    if raw:
+        try:
+            data = json.loads(raw)
+            jobs = data if isinstance(data, list) else data.get("jobs", [])
+            result = []
+            for item in jobs:
+                result.append({
                     "name": item.get("name", ""),
-                    "schedule": item.get("schedule", ""),
+                    "schedule": str(item.get("schedule", "")),
                     "enabled": item.get("enabled", True),
-                    "last_run": item.get("last_run", ""),
+                    "last_run": item.get("lastRun", item.get("last_run", "")),
                 })
-            return jobs
-    except Exception:
-        return []
+            return result
+        except Exception:
+            pass
+
+    # Fallback: parse text output
+    raw_text = await _run(["openclaw", "cron", "list"])
+    if raw_text:
+        result = []
+        for line in raw_text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            result.append({
+                "name": line[:80],
+                "schedule": "",
+                "enabled": True,
+                "last_run": "",
+            })
+        if result:
+            return result
+
+    # Fallback: read ~/.openclaw/openclaw.json
+    cfg_path = pathlib.Path.home() / ".openclaw" / "openclaw.json"
+    if cfg_path.exists():
+        try:
+            cfg = json.loads(cfg_path.read_text())
+            jobs = cfg.get("crons", cfg.get("jobs", []))
+            result = []
+            for item in (jobs if isinstance(jobs, list) else []):
+                result.append({
+                    "name": item.get("name", ""),
+                    "schedule": str(item.get("schedule", "")),
+                    "enabled": item.get("enabled", True),
+                    "last_run": item.get("lastRun", item.get("last_run", "")),
+                })
+            return result
+        except Exception:
+            pass
+
+    return []
 
 
 async def get_cron_status() -> list[dict]:

--- a/frontend/js/status.js
+++ b/frontend/js/status.js
@@ -133,23 +133,55 @@ class StatusDashboard {
 
         // ── AO Sessions ──────────────────────────────────────────
         const aoList = Array.isArray(ao_sessions) ? ao_sessions : [];
-        const aoRows = aoList.slice(0, 10).map(s => {
-            const dot   = s.status === 'active' ? 'sdot-g' : 'sdot-d';
-            const age   = this._fmtAge(s.age_seconds);
-            const last  = (s.last_line || '').slice(0, 60);
+        const isActive = s => {
+            const lastLine = (s.last_line || '').toLowerCase();
+            const bypass = lastLine.includes('bypass permissions');
+            return !bypass && (s.age_seconds !== null && s.age_seconds !== undefined && s.age_seconds < 1800);
+        };
+        const activeSessions = aoList.filter(isActive);
+        const idleSessions   = aoList.filter(s => !isActive(s));
+
+        const activeRows = activeSessions.map(s => {
+            const age  = this._fmtAge(s.age_seconds);
+            const last = (s.last_line || '').slice(0, 60);
             return `
                 <div class="srow">
-                    <div class="sdot ${dot}"></div>
+                    <div class="sdot sdot-g"></div>
                     <span class="srow-label orange">${esc(s.name)}</span>
                     <span class="srow-val">${esc(age)}&nbsp;&nbsp;${esc(last)}</span>
                 </div>
             `;
         }).join('');
 
+        let idleSection = '';
+        if (idleSessions.length > 0) {
+            const idleId = 'ao-idle-' + Date.now();
+            const idleDetailRows = idleSessions.map(s => {
+                const age  = this._fmtAge(s.age_seconds);
+                const last = (s.last_line || '').slice(0, 60);
+                return `
+                    <div class="srow dim">
+                        <div class="sdot sdot-d"></div>
+                        <span class="srow-label">${esc(s.name)}</span>
+                        <span class="srow-val">${esc(age)}&nbsp;&nbsp;${esc(last)}</span>
+                    </div>
+                `;
+            }).join('');
+            idleSection = `
+                <div class="srow ao-idle-toggle" style="cursor:pointer;color:var(--orange);user-select:none" onclick="var d=document.getElementById('${idleId}');d.style.display=d.style.display==='none'?'block':'none'">
+                    <div class="sdot sdot-d"></div>
+                    <span class="srow-label">${idleSessions.length} IDLE SESSION${idleSessions.length > 1 ? 'S' : ''} (click to expand)</span>
+                </div>
+                <div id="${idleId}" style="display:none">${idleDetailRows}</div>
+            `;
+        }
+
         html += `
             <div class="status-card">
                 <div class="status-card-title">AO SESSIONS (${aoList.length})</div>
-                ${aoRows || '<div class="srow"><span class="srow-label dim">● NO ACTIVE SESSIONS</span></div>'}
+                ${activeRows}
+                ${idleSection}
+                ${!activeRows && !idleSection ? '<div class="srow"><span class="srow-label dim">● NO ACTIVE SESSIONS</span></div>' : ''}
             </div>
         `;
 


### PR DESCRIPTION
## Summary
- Replace `get_openclaw_crons()` to use `openclaw cron list --json` CLI instead of gateway `/api/crons` (which returns 404); falls back to text-parse then `~/.openclaw/openclaw.json`
- Classify AO sessions as **active** (age < 30m and no `bypass permissions` in last line) vs **idle**; collapse idle sessions into a single click-to-expand row

## Test plan
- [ ] `ruff check backend/` passes (confirmed)
- [ ] `/api/status` returns `openclaw_crons` list or empty array (not an error)
- [ ] STATUS page shows compact idle sessions row with expand toggle

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)