### PR TITLE
feat: PSYCHE — recent decisions + active tasks + memory activity

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import random
 import time
+from datetime import datetime, timedelta
 import yaml
 import markdown as md_lib
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
@@ -17,8 +18,10 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 FRONTEND_DIR = pathlib.Path(__file__).parent.parent / "frontend"
-LAIN_MEMORY = pathlib.Path.home() / "agents" / "lain" / "memory"
-LAIN_WORKSPACE = pathlib.Path.home() / "agents" / "lain"
+LAIN_BASE = pathlib.Path.home() / "agents" / "lain"
+LAIN_MEMORY = LAIN_BASE / "memory"
+LAIN_WORKSPACE = LAIN_BASE
+STATE_FILE = LAIN_BASE / "STATE.yaml"
 
 app = FastAPI(title="Iwakura Platform", docs_url=None, redoc_url=None)
 
@@ -172,6 +175,73 @@ async def api_memory_file(filename: str):
     return JSONResponse({"name": filename, "content": content, "rendered": rendered})
 
 
+def get_recent_decisions() -> list:
+    """Extract last 8 headings/bullets from today's (or yesterday's) diary file."""
+    today = datetime.utcnow().strftime("%Y-%m-%d")
+    diary = LAIN_MEMORY / f"{today}.md"
+    if not diary.exists():
+        yesterday = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+        diary = LAIN_MEMORY / f"{yesterday}.md"
+    if not diary.exists():
+        return []
+    try:
+        text = diary.read_text(errors="replace")
+        entries = []
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("## ") or line.startswith("### "):
+                entries.append(line.lstrip("#").strip())
+            elif line.startswith("- ") and len(line) > 10:
+                entries.append(line[2:].strip()[:100])
+        return entries[-8:]
+    except Exception:
+        return []
+
+
+def get_active_task() -> dict:
+    """Read current task/goal from STATE.yaml."""
+    if not STATE_FILE.exists():
+        return {}
+    try:
+        with open(STATE_FILE) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {
+            "goal": str(data.get("goal", data.get("task", ""))),
+            "status": str(data.get("status", "")),
+            "remaining": data.get("remaining", []),
+        }
+    except Exception:
+        try:
+            text = STATE_FILE.read_text(errors="replace")
+            task: dict = {}
+            for line in text.splitlines():
+                if line.startswith("goal:") or line.startswith("task:"):
+                    task["goal"] = line.split(":", 1)[1].strip().strip('"')
+                elif line.startswith("status:"):
+                    task["status"] = line.split(":", 1)[1].strip().strip('"')
+            return task
+        except Exception:
+            return {}
+
+
+def get_memory_activity() -> dict:
+    """Count memory files and report last-modified info."""
+    try:
+        files = list(LAIN_MEMORY.glob("*.md"))
+        if not files:
+            return {}
+        latest = max(files, key=lambda f: f.stat().st_mtime)
+        return {
+            "file_count": len(files),
+            "latest_file": latest.name,
+            "latest_mtime": datetime.fromtimestamp(latest.stat().st_mtime).strftime("%Y-%m-%d %H:%M"),
+        }
+    except Exception:
+        return {}
+
+
 def _derive_mood(state: dict, initiative: dict, think: dict, think_delta: dict) -> dict:
     signals = []
     score = 0
@@ -268,6 +338,11 @@ async def api_psyche():
         data.get("think", {}),
         data.get("think_delta", {}),
     )
+
+    # enriched context
+    data["recent_decisions"] = get_recent_decisions()
+    data["active_task"] = get_active_task()
+    data["memory_activity"] = get_memory_activity()
 
     return JSONResponse(data)
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -766,6 +766,27 @@ mark.mem-kw-match {
     font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em;
 }
 
+/* Enriched context cards (issue #46) */
+.psyche-card {
+    padding: 8px 0 4px;
+    font-family: var(--font-mono); font-size: 12px;
+}
+.psyche-card-title {
+    font-family: var(--font-px); font-size: 7px;
+    color: var(--purple); letter-spacing: 0.3em;
+    margin-bottom: 6px;
+}
+.psyche-task-goal {
+    color: var(--cyan); padding: 2px 0;
+}
+.psyche-task-status {
+    color: var(--orange); font-size: 10px; opacity: 0.8;
+}
+.psyche-decision-line {
+    color: rgba(224,224,224,0.55); font-size: 11px;
+    padding: 1px 0; line-height: 1.4;
+}
+
 /* Legacy card styles kept for backward compatibility */
 .psy-card {
     background: rgba(15,15,53,0.6);

--- a/frontend/js/psyche.js
+++ b/frontend/js/psyche.js
@@ -72,6 +72,9 @@
                 soul_excerpt = '',
                 heartbeat = '',
                 mood = null,
+                recent_decisions = [],
+                active_task = {},
+                memory_activity = {},
             } = data;
 
             let html = '';
@@ -256,6 +259,41 @@
                 } else {
                     html += '<div class="screen-loading dim">PSYCHE DATA NOT ACCESSIBLE</div>';
                 }
+            }
+
+            // ── Active Task (from STATE.yaml) ──
+            if (active_task && active_task.goal) {
+                html += `
+                    <div class="psyche-card">
+                        <div class="psyche-card-title">ACTIVE TASK</div>
+                        <div class="psyche-task-goal">${esc(active_task.goal)}</div>
+                        ${active_task.status ? `<div class="psyche-task-status">${esc(active_task.status)}</div>` : ''}
+                    </div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Recent Decisions (from diary) ──
+            if (recent_decisions && recent_decisions.length > 0) {
+                html += `
+                    <div class="psyche-card">
+                        <div class="psyche-card-title">RECENT LOG</div>
+                        ${recent_decisions.map(d => `<div class="psyche-decision-line">· ${esc(d)}</div>`).join('')}
+                    </div>
+                    <div class="psy-rule"></div>
+                `;
+            }
+
+            // ── Memory Activity ──
+            if (memory_activity && memory_activity.file_count) {
+                html += `
+                    <div class="psyche-card">
+                        <div class="psyche-card-title">MEMORY</div>
+                        <div>${esc(String(memory_activity.file_count))} DIARY FILES · LAST: ${esc(memory_activity.latest_file || '')}</div>
+                        <div class="dim">${esc(memory_activity.latest_mtime || '')}</div>
+                    </div>
+                    <div class="psy-rule"></div>
+                `;
             }
 
             // ── Session ──


### PR DESCRIPTION
## Summary
- Adds `get_recent_decisions()` — extracts last 8 headings/bullets from today's (or yesterday's) diary file in `~/agents/lain/memory/`
- Adds `get_active_task()` — reads goal/status from `~/agents/lain/STATE.yaml` with graceful fallback if missing
- Adds `get_memory_activity()` — counts `.md` files and reports last-modified name/time
- `/api/psyche` now returns `recent_decisions`, `active_task`, `memory_activity` keys
- PSYCHE screen renders three new cards: **ACTIVE TASK**, **RECENT LOG**, **MEMORY**

## Test plan
- [ ] `ruff check backend/` passes (confirmed clean)
- [ ] `GET /api/psyche` returns all three new keys
- [ ] PSYCHE screen displays new cards when data is present
- [ ] Works gracefully when `STATE.yaml` or diary files are absent

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)