### PR TITLE
feat: TASKS screen — live task board from STATE.yaml

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -389,6 +389,92 @@ async def api_psyche():
     return JSONResponse(data)
 
 
+@app.get("/api/tasks")
+async def api_tasks():
+    state_path = LAIN_MEMORY / "STATE.yaml"
+    tasks_out = []
+    metrics_out = {
+        "active_count": 0,
+        "done_count": 0,
+        "paused_count": 0,
+        "tests_passing": None,
+        "prs_merged": None,
+        "features_shipped": None,
+    }
+
+    if state_path.exists():
+        try:
+            raw = yaml.safe_load(state_path.read_text()) or {}
+        except Exception:
+            raw = {}
+
+        tasks_raw = raw.get("tasks", [])
+        if isinstance(tasks_raw, dict):
+            tasks_raw = [tasks_raw]
+        elif not isinstance(tasks_raw, list):
+            tasks_raw = []
+
+        for t in tasks_raw:
+            if not isinstance(t, dict):
+                continue
+
+            status_raw = str(t.get("status", "")).lower()
+            if status_raw in ("in_progress", "running"):
+                status = "RUNNING"
+                metrics_out["active_count"] += 1
+            elif status_raw in ("paused",):
+                status = "PAUSED"
+                metrics_out["paused_count"] += 1
+            elif status_raw in ("done", "complete", "completed"):
+                status = "DONE"
+                metrics_out["done_count"] += 1
+            else:
+                status = status_raw.upper() or "PENDING"
+
+            done_list = t.get("done", [])
+            if not isinstance(done_list, list):
+                done_list = []
+            remaining_list = t.get("remaining", [])
+            if not isinstance(remaining_list, list):
+                remaining_list = []
+
+            stats = t.get("stats", {}) or {}
+            done_count = int(stats.get("tasks_done", len(done_list)))
+            remaining_count = len(remaining_list)
+            total = done_count + remaining_count
+            pct = round(done_count / total * 100, 1) if total > 0 else 0.0
+
+            # Extract top-level metrics from stats
+            if metrics_out["tests_passing"] is None and stats.get("tests_passing") is not None:
+                metrics_out["tests_passing"] = stats["tests_passing"]
+            if metrics_out["prs_merged"] is None and stats.get("prs_merged_total") is not None:
+                metrics_out["prs_merged"] = stats["prs_merged_total"]
+            if metrics_out["features_shipped"] is None and stats.get("features_shipped") is not None:
+                metrics_out["features_shipped"] = str(stats["features_shipped"])
+
+            # Wave status summary
+            wave_status = t.get("wave_status", [])
+            if not isinstance(wave_status, list):
+                wave_status = []
+
+            tasks_out.append({
+                "id": str(t.get("id", "")),
+                "goal": str(t.get("goal", ""))[:120],
+                "status": status,
+                "progress": {
+                    "done": done_count,
+                    "remaining": remaining_count,
+                    "pct": pct,
+                },
+                "recent_done": [str(x) for x in done_list[-3:]],
+                "next_remaining": [str(x) for x in remaining_list[:3]],
+                "wave_status": [str(x) for x in wave_status[-3:]],
+                "stats": {str(k): str(v) for k, v in stats.items()},
+            })
+
+    return JSONResponse({"tasks": tasks_out, "metrics": metrics_out})
+
+
 @app.get("/api/session")
 async def api_session():
     return JSONResponse({"sessionId": gateway.get_current_session_id()})

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -928,6 +928,74 @@ body.flicker { animation: flicker-pulse 100ms forwards; }
     .screen.exiting      { animation: none; opacity: 0; }
 }
 
+/* ── Tasks Screen ──────────────────────────────────────────── */
+.tasks-grid {
+    flex: 1; overflow-y: auto;
+    padding: 0 20px 20px;
+    display: flex; flex-direction: column;
+    gap: 0;
+    scrollbar-width: thin;
+    scrollbar-color: var(--cyan) var(--bg-deep);
+}
+.tasks-grid::-webkit-scrollbar { width: 5px; }
+.tasks-grid::-webkit-scrollbar-track { background: var(--bg-deep); }
+.tasks-grid::-webkit-scrollbar-thumb { background: var(--cyan); }
+
+.tasks-metrics-bar {
+    display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+    padding: 8px 0;
+    font-family: var(--font-mono); font-size: 11px;
+    color: var(--text-dim);
+    flex-shrink: 0;
+}
+.tasks-met-item { white-space: nowrap; }
+.tasks-met-sep  { color: var(--text-dim); opacity: 0.4; }
+.tasks-met-divider { color: var(--orange); margin: 0 6px; }
+
+.task-card {
+    border: 1px solid rgba(0, 212, 170, 0.18);
+    border-left: 3px solid var(--cyan);
+    background: rgba(0, 212, 170, 0.03);
+    padding: 12px 14px;
+    margin-bottom: 14px;
+    font-family: var(--font-mono); font-size: 12px;
+    flex-shrink: 0;
+}
+.task-card-header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 6px;
+}
+.task-id { font-size: 10px; }
+.task-status-badge {
+    font-family: var(--font-px); font-size: 7px;
+    letter-spacing: 0.2em;
+    padding: 2px 6px;
+    border: 1px solid currentColor;
+}
+.task-goal {
+    color: var(--text-main); font-size: 13px;
+    line-height: 1.4; margin-bottom: 8px;
+}
+.task-progress-row {
+    display: flex; align-items: center; gap: 10px;
+    margin-bottom: 8px; font-size: 11px;
+}
+.task-progress-bar { letter-spacing: 0.05em; }
+.task-progress-pct { font-weight: bold; }
+.task-progress-counts { font-size: 10px; }
+
+.task-section-label {
+    font-family: var(--font-px); font-size: 7px;
+    letter-spacing: 0.3em; margin: 8px 0 4px;
+}
+.task-wave-item,
+.task-done-item,
+.task-remaining-item {
+    font-size: 11px; line-height: 1.5;
+    padding: 1px 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
 /* ── Animations ────────────────────────────────────────────── */
 @keyframes blink {
     0%, 100% { opacity: 1; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -58,6 +58,10 @@
             <div class="nav-label-code">Ira007</div>
             <div class="nav-label-name">PSYCHE</div>
         </div>
+        <div class="nav-label-item" data-target="tasks">
+            <div class="nav-label-code">Tsk099</div>
+            <div class="nav-label-name">TASKS</div>
+        </div>
     </div>
 
     <div class="hub-ui">
@@ -160,6 +164,19 @@
     </div>
 </div>
 
+<!-- ── TASKS SCREEN ───────────────────────────────────── -->
+<div id="screen-tasks" class="screen">
+    <div class="screen-header">
+        <button class="back-btn" data-target="hub">◀ RETURN</button>
+        <span class="screen-title" data-glitch>TASKS // LIVE TASK BOARD</span>
+        <span class="screen-code green">Tsk099</span>
+        <button id="tasks-refresh" class="refresh-btn">↻ REFRESH</button>
+    </div>
+    <div class="tasks-grid" id="tasks-content">
+        <div class="screen-loading cyan">LOADING TASK DATA<span class="loading-dots"></span></div>
+    </div>
+</div>
+
 <!-- ── VOLUME CONTROL ─────────────────────────────────── -->
 <div id="volume-control">
     <span class="vol-icon" id="vol-icon">♪</span>
@@ -189,6 +206,7 @@
                 <tr><td class="green">2</td><td>Go to STATUS</td></tr>
                 <tr><td class="green">3</td><td>Go to MEMORY</td></tr>
                 <tr><td class="green">4</td><td>Go to PSYCHE</td></tr>
+                <tr><td class="green">5</td><td>Go to TASKS</td></tr>
                 <tr><td class="green">Esc</td><td>Return to HUB</td></tr>
                 <tr><td class="green">m</td><td>Toggle mute</td></tr>
                 <tr><td class="green">?</td><td>Show / hide this panel</td></tr>
@@ -213,6 +231,7 @@
 <script src="js/psyche.js"></script>
 <script src="js/memory.js"></script>
 <script src="js/status.js"></script>
+<script src="js/tasks.js"></script>
 <script src="js/hotkeys.js"></script>
 <script src="js/app.js"></script>
 </body>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -13,6 +13,7 @@
     let memory        = null;
     let psyche        = null;
     let statusDash    = null;
+    let tasksDash     = null;
 
     // ── DOM refs ──────────────────────────────────────────────
     const screens = {
@@ -22,6 +23,7 @@
         status: document.getElementById('screen-status'),
         memory: document.getElementById('screen-memory'),
         psyche: document.getElementById('screen-psyche'),
+        tasks:  document.getElementById('screen-tasks'),
     };
 
     // ── Screen management ─────────────────────────────────────
@@ -49,6 +51,7 @@
             if (name === 'status') loadStatus();
             if (name === 'memory') initMemory();
             if (name === 'psyche') loadPsyche();
+            if (name === 'tasks')  loadTasks();
 
             // Stop hub Three.js when leaving
             if (name !== 'hub' && orbNav) orbNav.stop();
@@ -61,6 +64,9 @@
 
             // Stop status auto-refresh when leaving status
             if (name !== 'status' && statusDash) statusDash.stop();
+
+            // Stop tasks auto-refresh when leaving tasks
+            if (name !== 'tasks' && tasksDash) tasksDash.stop();
 
             // Unread badge: mark diary active/inactive
             if (chat) {
@@ -276,6 +282,21 @@
         psyche.init();
     }
 
+    // ── Tasks Screen ──────────────────────────────────────────
+
+    function loadTasks() {
+        const el = document.getElementById('tasks-content');
+        if (!el) return;
+
+        if (!tasksDash) {
+            el.innerHTML = '<div class="screen-loading cyan">LOADING TASK DATA<span class="loading-dots"></span></div>';
+            tasksDash = new TasksScreen(el);
+        } else {
+            tasksDash.stop();
+        }
+        tasksDash.start();
+    }
+
     // ── Back buttons ──────────────────────────────────────────
 
     document.querySelectorAll('.back-btn').forEach(btn => {
@@ -295,6 +316,14 @@
         statusRefresh.addEventListener('click', () => {
             if (window.audio) window.audio.playClick();
             if (statusDash) statusDash.refresh();
+        });
+    }
+
+    const tasksRefresh = document.getElementById('tasks-refresh');
+    if (tasksRefresh) {
+        tasksRefresh.addEventListener('click', () => {
+            if (window.audio) window.audio.playClick();
+            if (tasksDash) tasksDash.refresh();
         });
     }
 
@@ -374,7 +403,7 @@
     // Expose for debugging and hotkeys
     window.iwakura = {
         showScreen,
-        loadStatus, initMemory, loadPsyche,
+        loadStatus, initMemory, loadPsyche, loadTasks,
         getPsyche: () => psyche,
         currentScreen: () => currentScreen,
         clearDiaryUnread: () => { if (chat) chat.clearUnread(); },

--- a/frontend/js/hotkeys.js
+++ b/frontend/js/hotkeys.js
@@ -46,7 +46,7 @@ class IwakuraHotkeys {
 
         if (this._isTyping()) return;
 
-        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche' };
+        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche', '5': 'tasks' };
 
         if (screenMap[e.key]) {
             if (window.audio) window.audio.playClick();

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -26,9 +26,10 @@ class OrbitalNav {
         // Nav items — distributed on a single orbital torus
         this.navDefs = [
             { id: 'diary',  label: 'DIARY',  color: 0xff8c00, baseAngle: 0 },
-            { id: 'status', label: 'STATUS', color: 0x00d4aa, baseAngle: Math.PI * 0.5 },
-            { id: 'memory', label: 'MEMORY', color: 0x8b7cc8, baseAngle: Math.PI },
-            { id: 'psyche', label: 'PSYCHE', color: 0x4488ff, baseAngle: Math.PI * 1.5 },
+            { id: 'status', label: 'STATUS', color: 0x00d4aa, baseAngle: Math.PI * 0.4 },
+            { id: 'memory', label: 'MEMORY', color: 0x8b7cc8, baseAngle: Math.PI * 0.8 },
+            { id: 'psyche', label: 'PSYCHE', color: 0x4488ff, baseAngle: Math.PI * 1.2 },
+            { id: 'tasks',  label: 'TASKS',  color: 0x00ff88, baseAngle: Math.PI * 1.6 },
         ];
 
         // Label elements

--- a/frontend/js/tasks.js
+++ b/frontend/js/tasks.js
@@ -1,0 +1,168 @@
+/* ── Iwakura Platform — Tasks Screen ─────────────────────────────────────────
+   Fetches /api/tasks every 15s, renders PSX-style Lain task board
+   ─────────────────────────────────────────────────────────────────────────── */
+
+(function () {
+    'use strict';
+
+    class TasksScreen {
+        constructor(contentEl) {
+            this._el    = contentEl;
+            this._timer = null;
+        }
+
+        start() {
+            this._fetch();
+            if (this._timer) clearInterval(this._timer);
+            this._timer = setInterval(() => this._fetch(), 15000);
+        }
+
+        stop() {
+            if (this._timer) { clearInterval(this._timer); this._timer = null; }
+        }
+
+        refresh() {
+            this._fetch();
+        }
+
+        async _fetch() {
+            try {
+                const res = await fetch('/api/tasks');
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                const data = await res.json();
+                this._render(data);
+            } catch (e) {
+                if (this._el.querySelector('.screen-loading')) {
+                    this._el.innerHTML = '<div class="screen-loading red">TASK DATA INACCESSIBLE</div>';
+                }
+            }
+        }
+
+        _statusColor(status) {
+            switch (status) {
+                case 'RUNNING':  return '#00d4aa';   // cyan
+                case 'PAUSED':   return '#ff8c00';   // orange
+                case 'DONE':     return '#00ff88';   // green
+                default:         return '#8b7cc8';   // purple/gray
+            }
+        }
+
+        _progressBar(pct) {
+            const filled = Math.round(pct / 10);
+            const empty  = 10 - filled;
+            return '█'.repeat(filled) + '░'.repeat(empty);
+        }
+
+        _renderMetrics(metrics) {
+            const active   = metrics.active_count   || 0;
+            const done     = metrics.done_count     || 0;
+            const paused   = metrics.paused_count   || 0;
+            const tests    = metrics.tests_passing  != null ? String(metrics.tests_passing) : '--';
+            const prs      = metrics.prs_merged     != null ? String(metrics.prs_merged)    : '--';
+            const shipped  = metrics.features_shipped || '--';
+
+            return `
+                <div class="tasks-metrics-bar">
+                    <span class="cyan">TASKS:</span>
+                    <span class="tasks-met-item"><span class="cyan">${active}</span> active</span>
+                    <span class="tasks-met-sep">·</span>
+                    <span class="tasks-met-item"><span class="green">${done}</span> done</span>
+                    ${paused ? `<span class="tasks-met-sep">·</span><span class="tasks-met-item"><span class="orange">${paused}</span> paused</span>` : ''}
+                    <span class="tasks-met-divider">|</span>
+                    <span class="tasks-met-item">PRs: <span class="green">${prs}</span></span>
+                    <span class="tasks-met-sep">·</span>
+                    <span class="tasks-met-item">Tests: <span class="green">${tests}</span></span>
+                    <span class="tasks-met-sep">·</span>
+                    <span class="tasks-met-item">Shipped: <span class="orange">${esc(shipped)}</span></span>
+                </div>
+                <div class="psy-rule"></div>
+            `;
+        }
+
+        _renderTask(task) {
+            const color    = this._statusColor(task.status);
+            const progress = task.progress || { done: 0, remaining: 0, pct: 0 };
+            const bar      = this._progressBar(progress.pct);
+
+            let html = `
+                <div class="task-card">
+                    <div class="task-card-header">
+                        <span class="task-id dim">[ ${esc(task.id || 'TASK')} ]</span>
+                        <span class="task-status-badge" style="color:${color}">${esc(task.status)}</span>
+                    </div>
+                    <div class="task-goal">${esc(task.goal || 'No goal')}</div>
+                    <div class="task-progress-row">
+                        <span class="task-progress-bar" style="color:${color}">${bar}</span>
+                        <span class="task-progress-pct" style="color:${color}">${progress.pct}%</span>
+                        <span class="task-progress-counts dim">(${progress.done} done / ${progress.remaining} left)</span>
+                    </div>
+            `;
+
+            // Wave status (last 3)
+            if (task.wave_status && task.wave_status.length > 0) {
+                html += `<div class="task-section-label dim">WAVES</div>`;
+                task.wave_status.forEach(w => {
+                    html += `<div class="task-wave-item dim">▸ ${esc(w)}</div>`;
+                });
+            }
+
+            // Recent done items
+            if (task.recent_done && task.recent_done.length > 0) {
+                html += `<div class="task-section-label green">RECENT DONE</div>`;
+                task.recent_done.forEach(d => {
+                    const short = d.length > 100 ? d.slice(0, 97) + '...' : d;
+                    html += `<div class="task-done-item"><span class="green">✓</span> <span class="dim">${esc(short)}</span></div>`;
+                });
+            }
+
+            // Next remaining items
+            if (task.next_remaining && task.next_remaining.length > 0) {
+                html += `<div class="task-section-label cyan">NEXT UP</div>`;
+                task.next_remaining.forEach(r => {
+                    const short = r.length > 100 ? r.slice(0, 97) + '...' : r;
+                    html += `<div class="task-remaining-item"><span class="orange">→</span> <span class="dim">${esc(short)}</span></div>`;
+                });
+            }
+
+            html += `</div>`;
+            return html;
+        }
+
+        _render(data) {
+            const { tasks = [], metrics = {} } = data;
+
+            let html = '';
+
+            // Header bar
+            const ts = new Date().toISOString().slice(11, 19) + 'Z';
+            html += `
+                <div class="psy-header-bar">
+                    <span class="psy-file-code green">Tsk099</span>
+                    <span class="psy-title">TASK BOARD</span>
+                    <span class="psy-ts dim">${ts}</span>
+                </div>
+                <div class="psy-rule"></div>
+            `;
+
+            // Metrics bar
+            html += this._renderMetrics(metrics);
+
+            // Task cards
+            if (tasks.length === 0) {
+                html += '<div class="screen-loading dim">NO ACTIVE TASKS</div>';
+            } else {
+                tasks.forEach(t => { html += this._renderTask(t); });
+            }
+
+            this._el.innerHTML = html;
+        }
+    }
+
+    function esc(s) {
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    window.TasksScreen = TasksScreen;
+})();


### PR DESCRIPTION
## Summary
- Adds a 5th navigation node **TASKS** (code `Tsk099`, green) to the orbital hub
- New `GET /api/tasks` endpoint reads `STATE.yaml`, returns tasks with progress, recent done, and next remaining items
- `frontend/js/tasks.js`: PSX-styled `TasksScreen` class with color-coded status badges, `█░` progress bars, auto-refresh every 15s
- Hotkey `5` navigates to TASKS screen
- Task cards: cyan=RUNNING, orange=PAUSED, green=DONE, with wave status, recent done (✓), and next up (→)
- Empty state handled gracefully

## Test plan
- [ ] `GET /api/tasks` returns valid JSON with tasks and metrics
- [ ] Pressing `5` navigates to TASKS screen
- [ ] Task cards render with correct color coding
- [ ] Progress bar shows completion percentage
- [ ] Auto-refresh fires every 15s without flicker
- [ ] Empty/missing STATE.yaml returns empty state gracefully
- [ ] Back button returns to hub; stop() called on leave
- [ ] No regressions on other screens (1–4)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)