### PR TITLE
feat: STATUS kill idle AO sessions + auto-hide old sessions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -160,6 +160,12 @@ async def api_status():
     return JSONResponse(data)
 
 
+@app.delete("/api/ao-sessions/idle")
+async def api_kill_idle_sessions():
+    killed = await sys_status.kill_idle_ao_sessions()
+    return JSONResponse({"killed": killed, "count": len(killed)})
+
+
 @app.get("/api/memory")
 async def api_memory_list():
     files = []

--- a/backend/status.py
+++ b/backend/status.py
@@ -50,30 +50,49 @@ def _read_yaml(path: pathlib.Path) -> dict:
         return {}
 
 
-async def get_ao_sessions() -> list[dict]:
-    """List tmux sessions with iw- prefix and capture their last output."""
+async def get_ao_sessions() -> dict:
+    """List tmux sessions with iw- prefix and capture their last output.
+
+    Returns dict with:
+      - sessions: list of sessions created within last 24h (fully enumerated)
+      - old_count: count of sessions older than 24h (not enumerated)
+    """
     raw = await _run([
         "tmux", "list-sessions",
         "-F", "#{session_name}|#{session_created}|#{session_activity}"
     ])
     if not raw:
-        return []
+        return {"sessions": [], "old_count": 0}
 
     sessions = []
+    old_count = 0
     now = int(time.time())
+    THRESHOLD_24H = 86400
+
     for line in raw.splitlines():
         parts = line.strip().split("|")
         if len(parts) < 3:
             continue
-        name, _, activity_str = parts[0], parts[1], parts[2]
+        name, created_str, activity_str = parts[0], parts[1], parts[2]
         if "iw-" not in name:
             continue
+        try:
+            created_ts = int(created_str)
+        except ValueError:
+            created_ts = 0
         try:
             activity_ts = int(activity_str)
         except ValueError:
             activity_ts = 0
-        age_seconds = now - activity_ts if activity_ts else None
-        status = "active" if (age_seconds is not None and age_seconds < 60) else "idle"
+
+        age_seconds = now - created_ts if created_ts else None
+
+        # Sessions older than 24h: count only, don't enumerate
+        if age_seconds is not None and age_seconds > THRESHOLD_24H:
+            old_count += 1
+            continue
+
+        status = "active" if (activity_ts and now - activity_ts < 60) else "idle"
 
         last_line = await _run(["tmux", "capture-pane", "-t", name, "-p"])
         # get last non-empty line
@@ -83,10 +102,25 @@ async def get_ao_sessions() -> list[dict]:
         sessions.append({
             "name": name,
             "age_seconds": age_seconds,
+            "age_hours": round(age_seconds / 3600, 1) if age_seconds is not None else None,
             "last_line": last,
             "status": status,
         })
-    return sessions
+    return {"sessions": sessions, "old_count": old_count}
+
+
+async def kill_idle_ao_sessions() -> list[str]:
+    """Kill tmux sessions that are idle (bypass permissions) and older than 1 hour."""
+    result = await get_ao_sessions()
+    sessions = result["sessions"]
+    killed = []
+    for s in sessions:
+        is_idle = "bypass permissions" in (s.get("last_line") or "").lower()
+        old_enough = (s.get("age_seconds") or 0) > 3600
+        if is_idle and old_enough:
+            await _run(["tmux", "kill-session", "-t", s["name"]])
+            killed.append(s["name"])
+    return killed
 
 
 async def get_openclaw_crons() -> list[dict]:
@@ -254,7 +288,7 @@ def get_memory_file_stats() -> list[dict]:
 
 
 async def get_full_status() -> dict:
-    crons, docker, memory, ao_sessions, openclaw_crons = await asyncio.gather(
+    crons, docker, memory, ao_result, openclaw_crons = await asyncio.gather(
         get_cron_status(),
         get_docker_status(),
         get_memory_usage(),
@@ -268,7 +302,8 @@ async def get_full_status() -> dict:
     return {
         "timestamp": datetime.utcnow().isoformat() + "Z",
         "crons": crons,
-        "ao_sessions": ao_sessions,
+        "ao_sessions": ao_result["sessions"],
+        "ao_sessions_old_count": ao_result["old_count"],
         "openclaw_crons": openclaw_crons,
         "docker": docker,
         "memory": memory,

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -460,6 +460,7 @@ body::after {
     color: var(--orange); letter-spacing: 0.3em;
     margin-bottom: 10px; padding-bottom: 6px;
     border-bottom: 1px solid rgba(255,140,0,0.25);
+    display: flex; align-items: center; justify-content: space-between;
 }
 .srow {
     display: flex; align-items: center; gap: 8px;
@@ -510,6 +511,26 @@ body::after {
     padding: 4px 10px; cursor: pointer; transition: all 0.2s;
 }
 .refresh-btn:hover { background: var(--cyan); color: var(--bg-deep); }
+
+.kill-idle-btn {
+    background: transparent; border: 1px solid var(--orange);
+    color: var(--orange); font-family: var(--font-mono); font-size: 7px;
+    padding: 2px 7px; cursor: pointer; transition: all 0.2s;
+    letter-spacing: 0.1em; flex-shrink: 0;
+}
+.kill-idle-btn:hover { border-color: var(--red); color: var(--red); }
+
+.sessions-hidden-badge { color: var(--dim); font-size: 10px; }
+
+.status-toast {
+    position: fixed; bottom: 24px; right: 24px; z-index: 9999;
+    background: rgba(10,10,26,0.95); border: 1px solid var(--green);
+    color: var(--green); font-family: var(--font-mono); font-size: 11px;
+    padding: 8px 16px;
+    animation: toast-in 0.2s ease;
+}
+.status-toast-error { border-color: var(--red); color: var(--red); }
+@keyframes toast-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 
 /* ── Memory Screen ─────────────────────────────────────────── */
 .memory-layout {

--- a/frontend/js/status.js
+++ b/frontend/js/status.js
@@ -80,8 +80,34 @@ class StatusDashboard {
         return `${m}m`;
     }
 
+    async _killIdleSessions() {
+        try {
+            const res = await fetch('/api/ao-sessions/idle', { method: 'DELETE' });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            const count = data.count || 0;
+            this._showToast(count > 0
+                ? `✓ ${count} session${count > 1 ? 's' : ''} terminated`
+                : '✓ no idle sessions found');
+            this.refresh();
+        } catch (e) {
+            this._showToast('✗ kill failed: ' + e.message, true);
+        }
+    }
+
+    _showToast(msg, isError = false) {
+        const existing = document.getElementById('status-toast');
+        if (existing) existing.remove();
+        const toast = document.createElement('div');
+        toast.id = 'status-toast';
+        toast.className = 'status-toast' + (isError ? ' status-toast-error' : '');
+        toast.textContent = msg;
+        document.body.appendChild(toast);
+        setTimeout(() => toast.remove(), 3500);
+    }
+
     _render(el, data) {
-        const { crons = [], ao_sessions, openclaw_crons, docker = [], memory = {}, lain = {} } = data;
+        const { crons = [], ao_sessions, ao_sessions_old_count, openclaw_crons, docker = [], memory = {}, lain = {} } = data;
         let html = '';
 
         // ── System / Memory ──────────────────────────────────────
@@ -132,7 +158,8 @@ class StatusDashboard {
         `;
 
         // ── AO Sessions ──────────────────────────────────────────
-        const aoList = Array.isArray(ao_sessions) ? ao_sessions : [];
+        const aoList  = Array.isArray(ao_sessions) ? ao_sessions : [];
+        const oldCount = ao_sessions_old_count || 0;
         const isActive = s => {
             const lastLine = (s.last_line || '').toLowerCase();
             const bypass = lastLine.includes('bypass permissions');
@@ -176,12 +203,20 @@ class StatusDashboard {
             `;
         }
 
+        const oldBadge = oldCount > 0
+            ? `<div class="srow"><span class="srow-label sessions-hidden-badge">● ${oldCount} SESSION${oldCount > 1 ? 'S' : ''} &gt;24h (hidden)</span></div>`
+            : '';
+
+        const totalVisible = aoList.length;
+        const killBtnHtml = `<button class="kill-idle-btn" id="kill-idle-btn">KILL IDLE ✕</button>`;
+
         html += `
             <div class="status-card">
-                <div class="status-card-title">AO SESSIONS (${aoList.length})</div>
+                <div class="status-card-title">AO SESSIONS (${totalVisible})${killBtnHtml}</div>
                 ${activeRows}
                 ${idleSection}
-                ${!activeRows && !idleSection ? '<div class="srow"><span class="srow-label dim">● NO ACTIVE SESSIONS</span></div>' : ''}
+                ${oldBadge}
+                ${!activeRows && !idleSection && !oldBadge ? '<div class="srow"><span class="srow-label dim">● NO ACTIVE SESSIONS</span></div>' : ''}
             </div>
         `;
 
@@ -258,6 +293,11 @@ class StatusDashboard {
         `;
 
         el.innerHTML = html;
+
+        const killBtn = document.getElementById('kill-idle-btn');
+        if (killBtn) {
+            killBtn.addEventListener('click', () => this._killIdleSessions());
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `DELETE /api/ao-sessions/idle` endpoint — kills tmux `iw-*` sessions with `bypass permissions` in last line and age > 1h
- `get_ao_sessions()` now returns `{sessions, old_count}`: sessions older than 24h are counted but not enumerated, cutting noise after long dev runs
- AO SESSIONS card header now shows a `KILL IDLE ✕` button (orange PSX style); click → kill → toast + auto-refresh
- Sessions >24h shown as `● N SESSIONS >24h (hidden)` badge instead of flooding the list

## Test plan
- [ ] Start STATUS screen, verify KILL IDLE ✕ button appears in AO SESSIONS card
- [ ] Click button — confirms toast shows `✓ N sessions terminated`
- [ ] After kill, idle sessions disappear from list
- [ ] If no sessions older than 1h with bypass permissions, toast shows `✓ no idle sessions found`
- [ ] Sessions older than 24h show as count badge, not full rows

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)