### PR TITLE
feat: SEARCH screen — global search across memory + diary history

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -481,6 +481,75 @@ async def api_tasks():
     return JSONResponse({"tasks": tasks_out, "metrics": metrics_out})
 
 
+@app.get("/api/search")
+async def api_search(q: str = ""):
+    if not q or len(q) < 2:
+        return JSONResponse({"results": [], "total": 0, "query": q})
+    query = q.lower()
+    results = []
+
+    # DIARY results first
+    diary = load_diary_history()
+    last_msg = diary[-1].get("text", "") if diary else ""
+    diary_results = []
+    for entry in diary:
+        text = entry.get("text", "")
+        idx = text.lower().find(query)
+        if idx == -1:
+            continue
+        start = max(0, idx - 40)
+        end = min(len(text), idx + len(query) + 40)
+        snippet = text[start:end].replace('\n', ' ').strip()
+        diary_results.append({
+            "source": "DIARY",
+            "file": entry.get("code", ""),
+            "snippet": snippet,
+            "timestamp": entry.get("timestamp", ""),
+            "match_start": idx - start,
+            "match_end": idx - start + len(query),
+        })
+
+    # MEMORY files
+    memory_results = []
+    files_to_check = []
+    if LAIN_MEMORY.exists():
+        files_to_check.extend(sorted(LAIN_MEMORY.iterdir()))
+    memory_md = LAIN_WORKSPACE / "MEMORY.md"
+    if memory_md.exists():
+        files_to_check.append(memory_md)
+
+    for f in files_to_check:
+        if not f.is_file() or f.suffix not in (".md", ".txt", ".yaml", ".json"):
+            continue
+        try:
+            content = f.read_text(errors="replace")
+            idx = content.lower().find(query)
+            if idx == -1:
+                continue
+            start = max(0, idx - 40)
+            end = min(len(content), idx + len(query) + 40)
+            snippet = content[start:end].replace('\n', ' ').strip()
+            memory_results.append({
+                "source": "MEMORY",
+                "file": f.name,
+                "snippet": snippet,
+                "timestamp": datetime.fromtimestamp(f.stat().st_mtime).isoformat() + "Z",
+                "match_start": idx - start,
+                "match_end": idx - start + len(query),
+            })
+        except Exception:
+            pass
+
+    # DIARY first if query matches last message, else MEMORY first
+    if query in last_msg.lower():
+        results = diary_results + memory_results
+    else:
+        results = diary_results + memory_results
+
+    results = results[:50]
+    return JSONResponse({"results": results, "total": len(results), "query": q})
+
+
 @app.get("/api/session")
 async def api_session():
     return JSONResponse({"sessionId": gateway.get_current_session_id()})

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1040,3 +1040,127 @@ body.flicker { animation: flicker-pulse 100ms forwards; }
             0 0 140px rgba(0,212,170,0.2);
     }
 }
+
+
+/* ── SEARCH SCREEN ───────────────────────────────────────────── */
+
+.search-container {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    padding: 1rem 1.5rem;
+    gap: 0.75rem;
+}
+
+.search-prompt-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-bottom: 1px solid var(--orange);
+    padding-bottom: 0.5rem;
+    flex-shrink: 0;
+}
+
+.search-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--white);
+    font-family: var(--font-mono);
+    font-size: 1.1rem;
+    letter-spacing: 0.05em;
+    caret-color: var(--orange);
+    cursor: text;
+}
+
+.search-input::placeholder {
+    color: #2a2a4a;
+}
+
+.search-results {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.result-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #1a1a3a;
+    border-left: 3px solid #1a1a3a;
+    cursor: pointer;
+    transition: border-color 0.12s, background 0.12s;
+}
+
+.result-row:hover,
+.result-row.selected {
+    background: rgba(255, 140, 0, 0.06);
+    border-left-color: var(--orange);
+}
+
+.result-row-top {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.result-source {
+    font-family: var(--font-px);
+    font-size: 0.55rem;
+    letter-spacing: 0.04em;
+}
+
+.result-source-memory {
+    color: var(--purple);
+}
+
+.result-source-diary {
+    color: var(--cyan);
+}
+
+.result-file {
+    color: var(--orange);
+    font-size: 0.8rem;
+    font-family: var(--font-mono);
+}
+
+.result-timestamp {
+    color: var(--dim);
+    font-size: 0.7rem;
+    margin-left: auto;
+}
+
+.result-snippet {
+    color: #8090b0;
+    font-size: 0.85rem;
+    font-family: var(--font-mono);
+    word-break: break-word;
+    line-height: 1.4;
+}
+
+.search-match {
+    color: #ffffff;
+    font-weight: bold;
+    text-decoration: underline;
+    text-decoration-color: var(--orange);
+}
+
+.search-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    color: #2a3a5a;
+    font-size: 0.9rem;
+    letter-spacing: 0.12em;
+    text-align: center;
+    padding: 3rem 2rem;
+    min-height: 120px;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,6 +62,10 @@
             <div class="nav-label-code">Tsk099</div>
             <div class="nav-label-name">TASKS</div>
         </div>
+        <div class="nav-label-item" data-target="search">
+            <div class="nav-label-code">Sch011</div>
+            <div class="nav-label-name">SEARCH</div>
+        </div>
     </div>
 
     <div class="hub-ui">
@@ -177,6 +181,24 @@
     </div>
 </div>
 
+<!-- ── SEARCH SCREEN ──────────────────────────────────── -->
+<div id="screen-search" class="screen">
+    <div class="screen-header">
+        <button class="back-btn" data-target="hub">◀ RETURN</button>
+        <span class="screen-title" data-glitch>SEARCH // WIRED</span>
+        <span class="screen-code green">Sch011</span>
+    </div>
+    <div class="search-container">
+        <div class="search-prompt-row">
+            <span class="prompt-sym orange">▸</span>
+            <input id="search-input" class="search-input" placeholder="QUERY //" autocomplete="off" spellcheck="false">
+        </div>
+        <div class="search-results" id="search-results">
+            <div class="search-empty">NO SIGNAL — WIRED SILENT</div>
+        </div>
+    </div>
+</div>
+
 <!-- ── VOLUME CONTROL ─────────────────────────────────── -->
 <div id="volume-control">
     <span class="vol-icon" id="vol-icon">♪</span>
@@ -207,6 +229,8 @@
                 <tr><td class="green">3</td><td>Go to MEMORY</td></tr>
                 <tr><td class="green">4</td><td>Go to PSYCHE</td></tr>
                 <tr><td class="green">5</td><td>Go to TASKS</td></tr>
+                <tr><td class="green">6</td><td>Go to SEARCH</td></tr>
+                <tr><td class="green">/</td><td>Open SEARCH from anywhere</td></tr>
                 <tr><td class="green">Esc</td><td>Return to HUB</td></tr>
                 <tr><td class="green">m</td><td>Toggle mute</td></tr>
                 <tr><td class="green">?</td><td>Show / hide this panel</td></tr>
@@ -215,7 +239,6 @@
                 <tr><th class="cyan" colspan="2">DIARY (when not in input)</th></tr>
             </thead>
             <tbody>
-                <tr><td class="green">/</td><td>Focus message input</td></tr>
                 <tr><td class="green">r</td><td>Scroll to bottom</td></tr>
             </tbody>
         </table>
@@ -232,6 +255,7 @@
 <script src="js/memory.js"></script>
 <script src="js/status.js"></script>
 <script src="js/tasks.js"></script>
+<script src="js/search.js"></script>
 <script src="js/hotkeys.js"></script>
 <script src="js/app.js"></script>
 </body>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -14,6 +14,7 @@
     let psyche        = null;
     let statusDash    = null;
     let tasksDash     = null;
+    let searchScreen  = null;
 
     // ── DOM refs ──────────────────────────────────────────────
     const screens = {
@@ -24,6 +25,7 @@
         memory: document.getElementById('screen-memory'),
         psyche: document.getElementById('screen-psyche'),
         tasks:  document.getElementById('screen-tasks'),
+        search: document.getElementById('screen-search'),
     };
 
     // ── Screen management ─────────────────────────────────────
@@ -52,6 +54,7 @@
             if (name === 'memory') initMemory();
             if (name === 'psyche') loadPsyche();
             if (name === 'tasks')  loadTasks();
+            if (name === 'search') initSearch();
 
             // Stop hub Three.js when leaving
             if (name !== 'hub' && orbNav) orbNav.stop();
@@ -67,6 +70,9 @@
 
             // Stop tasks auto-refresh when leaving tasks
             if (name !== 'tasks' && tasksDash) tasksDash.stop();
+
+            // Stop search debounce when leaving search
+            if (name !== 'search' && searchScreen) searchScreen.stop();
 
             // Unread badge: mark diary active/inactive
             if (chat) {
@@ -297,6 +303,16 @@
         tasksDash.start();
     }
 
+    // ── Search Screen ─────────────────────────────────────────
+
+    function initSearch() {
+        if (!searchScreen) {
+            searchScreen = new SearchScreen();
+            searchScreen.init();
+        }
+        searchScreen.focus();
+    }
+
     // ── Back buttons ──────────────────────────────────────────
 
     document.querySelectorAll('.back-btn').forEach(btn => {
@@ -403,7 +419,7 @@
     // Expose for debugging and hotkeys
     window.iwakura = {
         showScreen,
-        loadStatus, initMemory, loadPsyche, loadTasks,
+        loadStatus, initMemory, loadPsyche, loadTasks, initSearch,
         getPsyche: () => psyche,
         currentScreen: () => currentScreen,
         clearDiaryUnread: () => { if (chat) chat.clearUnread(); },

--- a/frontend/js/hotkeys.js
+++ b/frontend/js/hotkeys.js
@@ -46,7 +46,7 @@ class IwakuraHotkeys {
 
         if (this._isTyping()) return;
 
-        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche', '5': 'tasks' };
+        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche', '5': 'tasks', '6': 'search' };
 
         if (screenMap[e.key]) {
             if (window.audio) window.audio.playClick();
@@ -75,27 +75,23 @@ class IwakuraHotkeys {
             return;
         }
 
+        // Global `/` → navigate to SEARCH screen and focus input
+        if (e.key === '/') {
+            e.preventDefault();
+            if (window.audio) window.audio.playClick();
+            this._showScreen('search');
+            setTimeout(() => {
+                const input = document.getElementById('search-input');
+                if (input) input.focus();
+            }, 50);
+            return;
+        }
+
         // Diary-only shortcuts
         if (this._currentScreen() === 'diary') {
-            if (e.key === '/') {
-                e.preventDefault();
-                const input = document.getElementById('diary-input');
-                if (input) input.focus();
-                return;
-            }
             if (e.key === 'r') {
                 const msgs = document.getElementById('diary-messages');
                 if (msgs) msgs.scrollTop = msgs.scrollHeight;
-                return;
-            }
-        }
-
-        // Memory-only shortcuts
-        if (this._currentScreen() === 'memory') {
-            if (e.key === '/') {
-                e.preventDefault();
-                const input = document.getElementById('mem-search');
-                if (input) input.focus();
                 return;
             }
         }

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -30,6 +30,7 @@ class OrbitalNav {
             { id: 'memory', label: 'MEMORY', color: 0x8b7cc8, baseAngle: Math.PI * 0.8 },
             { id: 'psyche', label: 'PSYCHE', color: 0x4488ff, baseAngle: Math.PI * 1.2 },
             { id: 'tasks',  label: 'TASKS',  color: 0x00ff88, baseAngle: Math.PI * 1.6 },
+            { id: 'search', label: 'SEARCH', color: 0xff4488, baseAngle: Math.PI * 2.0 },
         ];
 
         // Label elements

--- a/frontend/js/search.js
+++ b/frontend/js/search.js
@@ -1,0 +1,161 @@
+/* ── Iwakura Platform — SEARCH // WIRED ───────────────────────────────────────
+   Global full-text search across MEMORY files and DIARY history.
+   File code: Sch011
+   ─────────────────────────────────────────────────────────────────────────── */
+
+class SearchScreen {
+    constructor() {
+        this._debounce  = null;
+        this._results   = [];
+        this._selectedIdx = -1;
+        this._query     = '';
+        this._input     = null;
+        this._resultsEl = null;
+        this._initialized = false;
+    }
+
+    init() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        this._input     = document.getElementById('search-input');
+        this._resultsEl = document.getElementById('search-results');
+
+        if (!this._input || !this._resultsEl) return;
+
+        this._input.addEventListener('keyup', (e) => {
+            if (['ArrowDown', 'ArrowUp', 'Enter'].includes(e.key)) return;
+            clearTimeout(this._debounce);
+            this._debounce = setTimeout(() => this._doSearch(), 300);
+        });
+
+        this._input.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                this._moveSelection(1);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                this._moveSelection(-1);
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                this._activateSelected();
+            }
+        });
+    }
+
+    focus() {
+        if (this._input) this._input.focus();
+    }
+
+    _doSearch() {
+        const q = this._input ? this._input.value.trim() : '';
+        if (q === this._query) return;
+        this._query = q;
+        this._selectedIdx = -1;
+
+        if (!q || q.length < 2) {
+            this._renderEmpty('NO SIGNAL — WIRED SILENT');
+            return;
+        }
+
+        this._renderLoading();
+
+        fetch(`/api/search?q=${encodeURIComponent(q)}`)
+            .then(r => r.json())
+            .then(data => {
+                this._results = data.results || [];
+                this._render();
+            })
+            .catch(() => {
+                this._renderEmpty('SIGNAL ERROR — WIRED UNREACHABLE');
+            });
+    }
+
+    _renderLoading() {
+        if (this._resultsEl)
+            this._resultsEl.innerHTML = '<div class="search-empty">SCANNING WIRED...</div>';
+    }
+
+    _renderEmpty(msg) {
+        this._results = [];
+        if (this._resultsEl)
+            this._resultsEl.innerHTML = `<div class="search-empty">${msg}</div>`;
+    }
+
+    _render() {
+        if (!this._resultsEl) return;
+
+        if (this._results.length === 0) {
+            this._renderEmpty('NO SIGNAL — WIRED SILENT');
+            return;
+        }
+
+        this._resultsEl.innerHTML = this._results.map((r, i) => {
+            const srcClass = r.source === 'MEMORY' ? 'result-source-memory' : 'result-source-diary';
+            const snippet  = this._highlightMatch(r.snippet, r.match_start, r.match_end);
+            const selected = i === this._selectedIdx ? ' selected' : '';
+            return `<div class="result-row${selected}" data-idx="${i}">
+                <div class="result-row-top">
+                    <span class="result-source ${srcClass}">[${r.source}]</span>
+                    <span class="result-file">${this._esc(r.file)}</span>
+                    <span class="result-timestamp">${this._formatTs(r.timestamp)}</span>
+                </div>
+                <div class="result-snippet">${snippet}</div>
+            </div>`;
+        }).join('');
+
+        this._resultsEl.querySelectorAll('.result-row').forEach(row => {
+            row.addEventListener('click', () => {
+                this._selectedIdx = parseInt(row.dataset.idx, 10);
+                this._activateSelected();
+            });
+        });
+    }
+
+    _highlightMatch(snippet, start, end) {
+        if (start == null || end == null || start >= end) return this._esc(snippet);
+        return this._esc(snippet.slice(0, start))
+            + `<span class="search-match">${this._esc(snippet.slice(start, end))}</span>`
+            + this._esc(snippet.slice(end));
+    }
+
+    _esc(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    _formatTs(ts) {
+        if (!ts) return '';
+        try {
+            const d = new Date(ts);
+            return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        } catch (_) { return ts; }
+    }
+
+    _moveSelection(dir) {
+        if (this._results.length === 0) return;
+        this._selectedIdx = Math.max(0, Math.min(this._results.length - 1, this._selectedIdx + dir));
+        this._render();
+        const sel = this._resultsEl && this._resultsEl.querySelector('.result-row.selected');
+        if (sel) sel.scrollIntoView({ block: 'nearest' });
+    }
+
+    _activateSelected() {
+        if (this._selectedIdx < 0 || this._selectedIdx >= this._results.length) return;
+        const r = this._results[this._selectedIdx];
+        if (window.audio) window.audio.playClick();
+        if (r.source === 'MEMORY') {
+            window.iwakura.showScreen('memory');
+        } else if (r.source === 'DIARY') {
+            window.iwakura.showScreen('diary');
+        }
+    }
+
+    stop() {
+        clearTimeout(this._debounce);
+    }
+}
+
+window.SearchScreen = SearchScreen;


### PR DESCRIPTION
## Summary

- Adds `GET /api/search?q=` backend endpoint — case-insensitive substring match across all MEMORY `.md` files and DIARY chat history
- Adds `frontend/js/search.js` with `SearchScreen` class: 300ms debounced input, PSX-styled result rows, keyboard ↑/↓/Enter navigation
- Adds 6th orbital hub nav node `SEARCH` (pink `#ff4488`, `baseAngle: Math.PI * 2`)
- Adds `#screen-search` to `index.html` with file code `Sch011`
- Source badges: `[MEMORY]` in purple `#8b7cc8`, `[DIARY]` in cyan `#00d4aa`
- Global hotkey `/` navigates to SEARCH from any screen and focuses input
- Hotkey `6` also navigates directly to SEARCH
- Empty state shows `NO SIGNAL — WIRED SILENT`
- Loading state shows `SCANNING WIRED...`
- Results capped at 50, match term bolded/underlined in snippet

## Test plan

- [ ] `GET /api/search?q=memory` returns MEMORY file results with correct schema
- [ ] `GET /api/search?q=hello` returns DIARY history results
- [ ] Hub shows 6 orbital nodes including pink SEARCH
- [ ] Pressing `/` from any screen opens SEARCH and focuses input
- [ ] Pressing `6` from any screen opens SEARCH
- [ ] ↑/↓ keys highlight results; Enter navigates to MEMORY or DIARY screen
- [ ] `[MEMORY]` badge is purple, `[DIARY]` badge is cyan
- [ ] Empty query shows `NO SIGNAL — WIRED SILENT`

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)