### PR TITLE
feat: WIRED screen — live activity stream + system telemetry

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,14 +1,16 @@
 """Iwakura Platform Backend — FastAPI + WebSocket + OpenClaw proxy."""
+import asyncio
 import json
 import logging
 import pathlib
 import random
 import time
+import uuid
 from datetime import datetime, timedelta
 import yaml
 import markdown as md_lib
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from starlette.websockets import WebSocketState
 
 import gateway
@@ -553,6 +555,164 @@ async def api_search(q: str = ""):
 @app.get("/api/session")
 async def api_session():
     return JSONResponse({"sessionId": gateway.get_current_session_id()})
+
+
+# ── WIRED — live activity stream ──────────────────────────────────────────────
+
+async def _build_wired_events() -> list[dict]:
+    """Aggregate last 50 events from DIARY, AO sessions, MEMORY, CRON, SYSTEM."""
+    events: list[dict] = []
+    now = datetime.utcnow()
+
+    # DIARY: last 10 messages
+    try:
+        diary = load_diary_history()
+        for entry in diary[-10:]:
+            role = entry.get("role", "user")
+            text = entry.get("text", "")
+            snippet = text[:70] + ("..." if len(text) > 70 else "")
+            arrow = "→" if role == "user" else "←"
+            label = "Human" if role == "user" else "Lain"
+            events.append({
+                "id": entry.get("code") or str(uuid.uuid4()),
+                "ts": entry.get("timestamp", now.isoformat() + "Z"),
+                "source": "DIARY",
+                "level": "info",
+                "text": f"{label} {arrow} {snippet}",
+                "detail": entry.get("code", ""),
+            })
+    except Exception:
+        pass
+
+    # AO SESSIONS: recent iw- tmux sessions
+    try:
+        ao_result = await sys_status.get_ao_sessions()
+        for s in ao_result.get("sessions", [])[:10]:
+            name = str(s.get("name", ""))
+            status = str(s.get("status", "unknown"))
+            last = str(s.get("last_line", ""))[:60]
+            age_h = s.get("age_hours")
+            age_str = f"{age_h:.1f}h ago" if age_h is not None else ""
+            events.append({
+                "id": "ao-" + name,
+                "ts": now.isoformat() + "Z",
+                "source": "AO",
+                "level": "info",
+                "text": f"{name} [{status}] {last}".strip(),
+                "detail": age_str,
+            })
+    except Exception:
+        pass
+
+    # MEMORY: files modified in last 24h
+    try:
+        cutoff = now.timestamp() - 86400
+        if LAIN_MEMORY.exists():
+            for f in sorted(LAIN_MEMORY.iterdir(), key=lambda x: x.stat().st_mtime, reverse=True)[:15]:
+                if not f.is_file():
+                    continue
+                stat = f.stat()
+                if stat.st_mtime < cutoff:
+                    continue
+                mtime = datetime.utcfromtimestamp(stat.st_mtime)
+                size_str = f"{stat.st_size // 1024}KB" if stat.st_size > 1024 else f"{stat.st_size}B"
+                events.append({
+                    "id": "mem-" + f.name,
+                    "ts": mtime.isoformat() + "Z",
+                    "source": "MEMORY",
+                    "level": "info",
+                    "text": f"write: {f.name} ({size_str})",
+                    "detail": f.name,
+                })
+    except Exception:
+        pass
+
+    # CRON: openclaw cron jobs with last_run
+    try:
+        crons = await sys_status.get_openclaw_crons()
+        for c in crons[:10]:
+            name = str(c.get("name", ""))[:40]
+            last_run = str(c.get("last_run", ""))
+            enabled = c.get("enabled", True)
+            level = "info" if enabled else "warn"
+            if name:
+                events.append({
+                    "id": "cron-" + name,
+                    "ts": last_run if last_run else now.isoformat() + "Z",
+                    "source": "CRON",
+                    "level": level,
+                    "text": f"{name} [{'enabled' if enabled else 'disabled'}] {c.get('schedule', '')}".strip(),
+                    "detail": last_run,
+                })
+    except Exception:
+        pass
+
+    # SYSTEM: memory health snapshot
+    try:
+        mem_info = await sys_status.get_memory_usage()
+        pct = mem_info.get("percent", 0)
+        level = "alert" if pct > 95 else ("warn" if pct > 85 else "info")
+        events.append({
+            "id": "sys-mem",
+            "ts": now.isoformat() + "Z",
+            "source": "SYSTEM",
+            "level": level,
+            "text": f"memory {pct:.1f}% used — {mem_info.get('used', '?')} / {mem_info.get('total', '?')}",
+            "detail": str(pct),
+        })
+    except Exception:
+        pass
+
+    # Sort descending by ts, cap at 50
+    try:
+        events.sort(key=lambda e: e.get("ts", ""), reverse=True)
+    except Exception:
+        pass
+    return events[:50]
+
+
+@app.get("/api/wired")
+async def api_wired():
+    events = await _build_wired_events()
+    return JSONResponse({"events": events, "total": len(events)})
+
+
+@app.get("/api/wired/stream")
+async def api_wired_stream():
+    """SSE stream: emits a 'wired' event every 5 seconds with latest events."""
+
+    async def event_generator():
+        last_ids: set[str] = set()
+        # Send initial full snapshot
+        events = await _build_wired_events()
+        last_ids = {e["id"] for e in events}
+        payload = json.dumps({"events": events, "total": len(events)})
+        yield f"data: {payload}\n\n"
+
+        while True:
+            await asyncio.sleep(5)
+            try:
+                events = await _build_wired_events()
+                new_ids = {e["id"] for e in events}
+                new_events = [e for e in events if e["id"] not in last_ids]
+                last_ids = new_ids
+                if new_events:
+                    payload = json.dumps({"events": events, "new": new_events, "total": len(events)})
+                    yield f"data: {payload}\n\n"
+                else:
+                    # Heartbeat to keep connection alive
+                    yield ": heartbeat\n\n"
+            except Exception:
+                yield ": error\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 # ── Static files + SPA fallback ───────────────────────────────────────────────

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1164,3 +1164,106 @@ body.flicker { animation: flicker-pulse 100ms forwards; }
     padding: 3rem 2rem;
     min-height: 120px;
 }
+
+/* ── WIRED Screen ─────────────────────────────────────────────────────────── */
+
+.wired-feed {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.wired-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.35rem 0.6rem;
+    border-left: 3px solid #444;
+    background: rgba(10, 10, 26, 0.7);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.4;
+    transition: background 0.15s;
+}
+
+.wired-row:hover {
+    background: rgba(30, 30, 60, 0.85);
+}
+
+/* Slide-in animation for new events */
+.wired-row-enter {
+    opacity: 0;
+    transform: translateY(-8px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.wired-row-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.wired-badge {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    min-width: 6ch;
+    flex-shrink: 0;
+    text-transform: uppercase;
+}
+
+.wired-text {
+    flex: 1;
+    color: #b0b8cc;
+    word-break: break-word;
+}
+
+.wired-text.wired-warn  { color: #ffcc00; }
+.wired-text.wired-alert { color: #ff4444; animation: wired-flash 1s infinite; }
+
+@keyframes wired-flash {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.5; }
+}
+
+.wired-ts {
+    font-size: 0.72rem;
+    color: #3a4a6a;
+    white-space: nowrap;
+    flex-shrink: 0;
+    text-align: right;
+    min-width: 7ch;
+}
+
+.wired-indicator {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: #3a4a6a;
+    letter-spacing: 0.08em;
+    margin-left: auto;
+    padding-right: 0.5rem;
+}
+
+.wired-indicator.live {
+    color: #00ff88;
+    animation: wired-blink 2s infinite;
+}
+
+@keyframes wired-blink {
+    0%, 80%, 100% { opacity: 1; }
+    40%           { opacity: 0.3; }
+}
+
+.wired-status-bar {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.4rem 1rem;
+    border-top: 1px solid #1a2a4a;
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: #3a4a6a;
+    flex-shrink: 0;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -66,6 +66,10 @@
             <div class="nav-label-code">Sch011</div>
             <div class="nav-label-name">SEARCH</div>
         </div>
+        <div class="nav-label-item" data-target="wired">
+            <div class="nav-label-code">Wrd001</div>
+            <div class="nav-label-name">WIRED</div>
+        </div>
     </div>
 
     <div class="hub-ui">
@@ -199,6 +203,21 @@
     </div>
 </div>
 
+<!-- ── WIRED SCREEN (live activity stream) ───────────── -->
+<div id="screen-wired" class="screen">
+    <div class="screen-header">
+        <button class="back-btn" data-target="hub">◀ RETURN</button>
+        <span class="screen-title" data-glitch>WIRED // ACTIVITY FEED</span>
+        <span class="screen-code green">Wrd001</span>
+        <span id="wired-live-indicator" class="wired-indicator">○ OFFLINE</span>
+    </div>
+    <div id="wired-feed" class="wired-feed"></div>
+    <div class="wired-status-bar">
+        <span id="wired-event-count" class="dim">0 events</span>
+        <span id="wired-last-update" class="dim"></span>
+    </div>
+</div>
+
 <!-- ── VOLUME CONTROL ─────────────────────────────────── -->
 <div id="volume-control">
     <span class="vol-icon" id="vol-icon">♪</span>
@@ -230,6 +249,7 @@
                 <tr><td class="green">4</td><td>Go to PSYCHE</td></tr>
                 <tr><td class="green">5</td><td>Go to TASKS</td></tr>
                 <tr><td class="green">6</td><td>Go to SEARCH</td></tr>
+                <tr><td class="green">7</td><td>Go to WIRED</td></tr>
                 <tr><td class="green">/</td><td>Open SEARCH from anywhere</td></tr>
                 <tr><td class="green">Esc</td><td>Return to HUB</td></tr>
                 <tr><td class="green">m</td><td>Toggle mute</td></tr>
@@ -256,6 +276,7 @@
 <script src="js/status.js"></script>
 <script src="js/tasks.js"></script>
 <script src="js/search.js"></script>
+<script src="js/wired.js"></script>
 <script src="js/hotkeys.js"></script>
 <script src="js/app.js"></script>
 </body>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -15,6 +15,7 @@
     let statusDash    = null;
     let tasksDash     = null;
     let searchScreen  = null;
+    let wiredScreen   = null;
 
     // ── DOM refs ──────────────────────────────────────────────
     const screens = {
@@ -26,6 +27,7 @@
         psyche: document.getElementById('screen-psyche'),
         tasks:  document.getElementById('screen-tasks'),
         search: document.getElementById('screen-search'),
+        wired:  document.getElementById('screen-wired'),
     };
 
     // ── Screen management ─────────────────────────────────────
@@ -55,6 +57,7 @@
             if (name === 'psyche') loadPsyche();
             if (name === 'tasks')  loadTasks();
             if (name === 'search') initSearch();
+            if (name === 'wired')  initWired();
 
             // Stop hub Three.js when leaving
             if (name !== 'hub' && orbNav) orbNav.stop();
@@ -73,6 +76,9 @@
 
             // Stop search debounce when leaving search
             if (name !== 'search' && searchScreen) searchScreen.stop();
+
+            // Stop wired SSE when leaving wired
+            if (name !== 'wired' && wiredScreen) wiredScreen.stop();
 
             // Unread badge: mark diary active/inactive
             if (chat) {
@@ -313,6 +319,17 @@
         searchScreen.focus();
     }
 
+    // ── WIRED Screen ──────────────────────────────────────────
+
+    function initWired() {
+        if (!wiredScreen) {
+            wiredScreen = new WiredScreen();
+        } else {
+            wiredScreen.stop();
+        }
+        wiredScreen.init();
+    }
+
     // ── Back buttons ──────────────────────────────────────────
 
     document.querySelectorAll('.back-btn').forEach(btn => {
@@ -419,7 +436,7 @@
     // Expose for debugging and hotkeys
     window.iwakura = {
         showScreen,
-        loadStatus, initMemory, loadPsyche, loadTasks, initSearch,
+        loadStatus, initMemory, loadPsyche, loadTasks, initSearch, initWired,
         getPsyche: () => psyche,
         currentScreen: () => currentScreen,
         clearDiaryUnread: () => { if (chat) chat.clearUnread(); },

--- a/frontend/js/hotkeys.js
+++ b/frontend/js/hotkeys.js
@@ -46,7 +46,7 @@ class IwakuraHotkeys {
 
         if (this._isTyping()) return;
 
-        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche', '5': 'tasks', '6': 'search' };
+        const screenMap = { '1': 'diary', '2': 'status', '3': 'memory', '4': 'psyche', '5': 'tasks', '6': 'search', '7': 'wired' };
 
         if (screenMap[e.key]) {
             if (window.audio) window.audio.playClick();

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -31,6 +31,7 @@ class OrbitalNav {
             { id: 'psyche', label: 'PSYCHE', color: 0x4488ff, baseAngle: Math.PI * 1.2 },
             { id: 'tasks',  label: 'TASKS',  color: 0x00ff88, baseAngle: Math.PI * 1.6 },
             { id: 'search', label: 'SEARCH', color: 0xff4488, baseAngle: Math.PI * 2.0 },
+            { id: 'wired',  label: 'WIRED',  color: 0xffcc00, baseAngle: Math.PI * 2.4 },
         ];
 
         // Label elements

--- a/frontend/js/wired.js
+++ b/frontend/js/wired.js
@@ -1,0 +1,235 @@
+/* ── Iwakura Platform — WIRED Screen (live activity stream) ──────────────────
+   SSE connection to /api/wired/stream with polling fallback.
+   Events are rendered as terminal rows color-coded by source.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+class WiredScreen {
+    constructor() {
+        this._feed       = null;
+        this._countEl    = null;
+        this._lastUpEl   = null;
+        this._indicator  = null;
+        this._evtSource  = null;
+        this._pollTimer  = null;
+        this._knownIds   = new Set();
+        this._userScrolled = false;
+        this._active     = false;
+    }
+
+    // Source → color mapping
+    static COLORS = {
+        DIARY:  '#ff8c00',   // orange
+        AO:     '#00d4aa',   // cyan
+        MEMORY: '#8b7cc8',   // purple
+        CRON:   '#00ff88',   // green
+        SYSTEM: '#ffcc00',   // yellow (alert → red handled in render)
+    };
+
+    static BADGES = {
+        DIARY:  'DIARY ',
+        AO:     'AO-SES',
+        MEMORY: 'MEMORY',
+        CRON:   'CRON  ',
+        SYSTEM: 'SYSTAT',
+    };
+
+    init() {
+        this._feed      = document.getElementById('wired-feed');
+        this._countEl   = document.getElementById('wired-event-count');
+        this._lastUpEl  = document.getElementById('wired-last-update');
+        this._indicator = document.getElementById('wired-live-indicator');
+        this._active    = true;
+        this._userScrolled = false;
+
+        if (this._feed) {
+            this._feed.addEventListener('scroll', () => {
+                // Consider user scrolled if not near top
+                this._userScrolled = this._feed.scrollTop > 80;
+            });
+        }
+
+        this._connect();
+    }
+
+    stop() {
+        this._active = false;
+        if (this._evtSource) {
+            this._evtSource.close();
+            this._evtSource = null;
+        }
+        if (this._pollTimer) {
+            clearInterval(this._pollTimer);
+            this._pollTimer = null;
+        }
+        if (this._indicator) {
+            this._indicator.classList.remove('live');
+            this._indicator.textContent = '○ OFFLINE';
+        }
+    }
+
+    // ── Connection ────────────────────────────────────────────
+
+    _connect() {
+        if (!this._active) return;
+
+        try {
+            const es = new EventSource('/api/wired/stream');
+            this._evtSource = es;
+
+            es.onopen = () => {
+                if (this._indicator) {
+                    this._indicator.textContent = '● LIVE';
+                    this._indicator.classList.add('live');
+                }
+            };
+
+            es.onmessage = (evt) => {
+                try {
+                    const data = JSON.parse(evt.data);
+                    if (data.events) this._render(data.events, data.new);
+                } catch (_) {}
+            };
+
+            es.onerror = () => {
+                es.close();
+                this._evtSource = null;
+                if (this._indicator) {
+                    this._indicator.textContent = '◌ POLLING';
+                    this._indicator.classList.remove('live');
+                }
+                this._startPolling();
+            };
+        } catch (_) {
+            this._startPolling();
+        }
+    }
+
+    _startPolling() {
+        if (this._pollTimer || !this._active) return;
+        this._fetchAndRender();
+        this._pollTimer = setInterval(() => {
+            if (!this._active) {
+                clearInterval(this._pollTimer);
+                this._pollTimer = null;
+                return;
+            }
+            this._fetchAndRender();
+        }, 5000);
+    }
+
+    async _fetchAndRender() {
+        try {
+            const res = await fetch('/api/wired');
+            if (!res.ok) return;
+            const data = await res.json();
+            if (data.events) this._render(data.events);
+        } catch (_) {}
+    }
+
+    // ── Rendering ─────────────────────────────────────────────
+
+    _render(events, newEvents) {
+        if (!this._feed) return;
+
+        const newIds = newEvents ? new Set(newEvents.map(e => e.id)) : null;
+
+        // Build set of existing DOM ids
+        const existing = new Set(
+            Array.from(this._feed.querySelectorAll('.wired-row[data-id]'))
+                 .map(el => el.dataset.id)
+        );
+
+        // Prepend truly new events with animation
+        const toAdd = events.filter(e => !existing.has(e.id));
+
+        // Build all rows in order (events already sorted desc by server)
+        if (existing.size === 0) {
+            // First render: add all at once
+            this._feed.innerHTML = '';
+            events.forEach(e => {
+                this._feed.appendChild(this._makeRow(e, false));
+            });
+        } else {
+            // Incremental: prepend new rows with slide-in
+            toAdd.forEach(e => {
+                const row = this._makeRow(e, true);
+                this._feed.insertBefore(row, this._feed.firstChild);
+                // Trigger animation
+                requestAnimationFrame(() => row.classList.add('wired-row-visible'));
+            });
+        }
+
+        // Trim to 100 events
+        const rows = this._feed.querySelectorAll('.wired-row');
+        if (rows.length > 100) {
+            for (let i = 100; i < rows.length; i++) rows[i].remove();
+        }
+
+        // Update known ids
+        events.forEach(e => this._knownIds.add(e.id));
+
+        // Status bar
+        if (this._countEl) this._countEl.textContent = `${events.length} events`;
+        if (this._lastUpEl) {
+            const now = new Date();
+            this._lastUpEl.textContent = `updated ${now.toLocaleTimeString()}`;
+        }
+
+        // Scroll to top on new events unless user scrolled down
+        if (toAdd.length > 0 && !this._userScrolled && this._feed) {
+            this._feed.scrollTop = 0;
+        }
+    }
+
+    _makeRow(event, animate) {
+        const source = (event.source || 'SYSTEM').toUpperCase();
+        const level  = (event.level  || 'info').toLowerCase();
+        const color  = WiredScreen.COLORS[source] || '#e0e0e0';
+        const badge  = WiredScreen.BADGES[source] || source.padEnd(6).slice(0, 6);
+
+        const row = document.createElement('div');
+        row.className = 'wired-row' + (animate ? ' wired-row-enter' : '');
+        row.dataset.id = event.id;
+        row.style.borderLeftColor = level === 'alert' ? '#ff4444' : color;
+
+        const ts = this._relTime(event.ts);
+
+        let textClass = '';
+        if (level === 'alert') textClass = ' wired-alert';
+        else if (level === 'warn') textClass = ' wired-warn';
+
+        row.innerHTML = `
+            <span class="wired-badge" style="color:${color}">${badge}</span>
+            <span class="wired-text${textClass}">${this._esc(event.text)}</span>
+            <span class="wired-ts">${ts}</span>
+        `;
+        return row;
+    }
+
+    _relTime(iso) {
+        if (!iso) return '';
+        try {
+            const d   = new Date(iso);
+            const now = Date.now();
+            const sec = Math.floor((now - d.getTime()) / 1000);
+            if (sec < 10)  return 'just now';
+            if (sec < 60)  return `${sec}s ago`;
+            const min = Math.floor(sec / 60);
+            if (min < 60)  return `${min}m ago`;
+            const hr = Math.floor(min / 60);
+            if (hr  < 24)  return `${hr}h ago`;
+            return d.toLocaleDateString();
+        } catch (_) {
+            return '';
+        }
+    }
+
+    _esc(str) {
+        return String(str || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+}
+
+window.WiredScreen = WiredScreen;


### PR DESCRIPTION
## Summary
- Adds 7th orbital nav node **WIRED** (yellow `#ffcc00`) with `'7'` hotkey
- `GET /api/wired` — returns last 50 events aggregated from DIARY messages, AO tmux sessions, MEMORY file writes (last 24h), CRON jobs, and SYSTEM memory health
- `GET /api/wired/stream` — SSE endpoint pushing new events every 5 seconds with polling fallback
- `wired.js` — `WiredScreen` class: SSE connection → polling fallback, color-coded terminal rows, slide-in animation for new events, auto-scrolls to top unless user has scrolled down, trims feed to 100 events

Color coding: DIARY=orange, AO=cyan, MEMORY=purple, CRON=green, SYSTEM=yellow/red alert

## Test plan
- [ ] Navigate to WIRED via orbital hub click
- [ ] Press `7` hotkey — navigates to WIRED
- [ ] `GET /api/wired` returns JSON with ≥1 event and `total` field
- [ ] `GET /api/wired/stream` emits SSE `data:` lines
- [ ] Events are color-coded by source
- [ ] Live indicator shows `● LIVE` when SSE connected
- [ ] New events animate in from top
- [ ] No console errors

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)