### PR TITLE
feat: PSX 3D visual overhaul — Lain silhouette, gyroscope rings, particles

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1290,3 +1290,64 @@ body.flicker { animation: flicker-pulse 100ms forwards; }
     box-shadow: 0 0 18px rgba(255,204,0,0.4);
 }
 .nav-label-item[data-target="wired"] .nav-label-code { color: #ffcc00; }
+
+/* ── Lain SVG Silhouette ───────────────────────────────────── */
+.lain-silhouette-wrap {
+    width: 90px;
+    height: 150px;
+    margin: 0 auto 12px;
+    pointer-events: none;
+    filter:
+        drop-shadow(0 0 6px rgba(0,212,170,0.6))
+        drop-shadow(0 0 18px rgba(0,212,170,0.3))
+        drop-shadow(0 0 40px rgba(0,212,170,0.12));
+    animation: lain-float 7s ease-in-out infinite;
+    opacity: 0.8;
+}
+.lain-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+@keyframes lain-float {
+    0%, 100% { transform: translateY(0); }
+    50%      { transform: translateY(-6px); }
+}
+
+/* ── Hub Visual Enhancements ───────────────────────────────── */
+
+/* Depth-fade for nav labels (set by JS via style.opacity) */
+.nav-label-item {
+    transition: all 0.2s, opacity 0.4s;
+}
+
+/* Soften the center label stack for integration with silhouette */
+.center-name {
+    text-shadow:
+        0 0 15px rgba(255,255,255,0.5),
+        0 0 40px rgba(0,212,170,0.35),
+        0 0 80px rgba(0,212,170,0.12);
+}
+
+.center-status {
+    text-shadow: 0 0 10px rgba(0,212,170,0.5);
+}
+
+/* Nav label — tasks */
+.nav-label-item[data-target="tasks"] { border-color: rgba(0,255,136,0.4); }
+.nav-label-item[data-target="tasks"]:hover {
+    background: rgba(0,255,136,0.12);
+    border-color: var(--green);
+    box-shadow: 0 0 18px rgba(0,255,136,0.35);
+}
+.nav-label-item[data-target="tasks"] .nav-label-code { color: var(--green); }
+
+/* Nav label — search */
+.nav-label-item[data-target="search"] { border-color: rgba(255,68,136,0.4); }
+.nav-label-item[data-target="search"]:hover {
+    background: rgba(255,68,136,0.12);
+    border-color: #ff4488;
+    box-shadow: 0 0 18px rgba(255,68,136,0.35);
+}
+.nav-label-item[data-target="search"] .nav-label-code { color: #ff4488; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -79,6 +79,26 @@
             <span class="header-code green">Ira042</span>
         </div>
         <div class="hub-center-label">
+            <!-- Lain silhouette — dark figure, glowing outline -->
+            <div class="lain-silhouette-wrap">
+                <svg class="lain-svg" viewBox="0 0 120 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <!-- Hair (bob cut outer) -->
+                    <path d="M60,8 C82,8 100,26 102,52 C104,68 97,84 88,94
+                             C88,44 75,16 60,16 C45,16 32,44 32,94
+                             C23,84 16,68 18,52 C20,26 38,8 60,8Z"
+                          fill="#06061a" stroke="#00d4aa" stroke-width="1.2"/>
+                    <!-- Face + neck + body -->
+                    <path d="M32,94 C32,44 45,16 60,16 C75,16 88,44 88,94
+                             C88,110 80,124 74,130 L74,142
+                             C92,146 110,164 114,190 L114,198 L6,198 L6,190
+                             C10,164 28,146 46,142 L46,130
+                             C40,124 32,110 32,94Z"
+                          fill="#06061a" stroke="#00d4aa" stroke-width="0.9"/>
+                    <!-- Eyes — minimal, mysterious -->
+                    <line x1="44" y1="74" x2="54" y2="74" stroke="#00d4aa" stroke-width="0.7" opacity="0.3"/>
+                    <line x1="66" y1="74" x2="76" y2="74" stroke="#00d4aa" stroke-width="0.7" opacity="0.3"/>
+                </svg>
+            </div>
             <div class="center-name" data-glitch>L A I N</div>
             <div class="center-status" id="hub-lain-status">● PRESENT</div>
         </div>

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -1,15 +1,16 @@
-/* ── Three.js Orbital Navigation ─────────────────────────────────────────────
-   Renders a 3D scene in the hub: central Lain node, orbital rings, nav spheres
-   HTML label overlays are positioned by projecting 3D coords to screen space
+/* ── Three.js Orbital Navigation — PSX Lain Aesthetic ────────────────────────
+   3D hub scene: Lain wireframe presence at center, two gyroscope orbital rings,
+   navigation spheres, floating dust particles, layered glow.
+   HTML label overlays projected from 3D to screen space.
    ─────────────────────────────────────────────────────────────────────────── */
 
 class OrbitalNav {
     constructor(canvas, labelsContainer, onNavigate) {
-        this.canvas          = canvas;
-        this.labelsEl        = labelsContainer;
-        this.onNavigate      = onNavigate;
-        this.running         = false;
-        this.hoveredId       = null;
+        this.canvas     = canvas;
+        this.labelsEl   = labelsContainer;
+        this.onNavigate = onNavigate;
+        this.running    = false;
+        this.hoveredId  = null;
 
         this.scene    = null;
         this.camera   = null;
@@ -18,12 +19,14 @@ class OrbitalNav {
         this.raycaster = null;
         this.mouse     = new THREE.Vector2(-9999, -9999);
 
-        this.lainMesh  = null;
-        this.rings     = [];
-        this.navMeshes = [];
-        this.particles = null;
+        this.lainMesh    = null;
+        this.lainInner   = null;
+        this.ringGroupA  = null;   // primary ring group (holds nav nodes)
+        this.ringGroupB  = null;   // secondary ring group (visual only)
+        this.dustGroup   = null;
+        this.navMeshes   = [];
 
-        // Nav items — distributed on a single orbital torus
+        // Nav items — 7 screens on the primary orbital ring
         this.navDefs = [
             { id: 'diary',  label: 'DIARY',  color: 0xff8c00, baseAngle: 0 },
             { id: 'status', label: 'STATUS', color: 0x00d4aa, baseAngle: Math.PI * 0.4 },
@@ -34,8 +37,8 @@ class OrbitalNav {
             { id: 'wired',  label: 'WIRED',  color: 0xffcc00, baseAngle: Math.PI * 2.4 },
         ];
 
-        // Label elements
         this.labelEls = {};
+        this._worldPos = new THREE.Vector3();  // reusable for label projection
     }
 
     // ── Init ──────────────────────────────────────────────────
@@ -44,16 +47,13 @@ class OrbitalNav {
         const W = this.canvas.clientWidth  || window.innerWidth;
         const H = this.canvas.clientHeight || window.innerHeight;
 
-        // Scene
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(0x0a0a1a, 0.055);
+        this.scene.fog = new THREE.FogExp2(0x0a0a1a, 0.038);
 
-        // Camera
         this.camera = new THREE.PerspectiveCamera(58, W / H, 0.1, 200);
-        this.camera.position.set(0, 1.5, 9);
+        this.camera.position.set(0, 1.2, 9);
         this.camera.lookAt(0, 0, 0);
 
-        // Renderer
         this.renderer = new THREE.WebGLRenderer({
             canvas: this.canvas,
             antialias: true,
@@ -61,7 +61,7 @@ class OrbitalNav {
         });
         this.renderer.setSize(W, H, false);
         this.renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
-        this.renderer.setClearColor(0x0a0a1a, 1);
+        this.renderer.setClearColor(0x050510, 1);
 
         this.clock     = new THREE.Clock();
         this.raycaster = new THREE.Raycaster();
@@ -77,105 +77,217 @@ class OrbitalNav {
 
     _buildScene() {
         this._createStarField();
+        this._createDust();
+        this._createCentralGlow();
         this._createLainNode();
         this._createOrbitalRings();
         this._createNavNodes();
         this._createLighting();
     }
 
+    /* — Deep-space star field (3 layers for depth) — */
     _createStarField() {
-        const count = 600;
-        const pos = new Float32Array(count * 3);
-        for (let i = 0; i < count * 3; i++) {
-            pos[i] = (Math.random() - 0.5) * 80;
-        }
-        const geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-        const mat = new THREE.PointsMaterial({ color: 0x2a3a5a, size: 0.06 });
-        this.scene.add(new THREE.Points(geo, mat));
+        const layers = [
+            { count: 1200, size: 0.04, color: 0x1a2a4a, spread: 100 },
+            { count: 500,  size: 0.09, color: 0x2a4a6a, spread: 55 },
+            { count: 150,  size: 0.16, color: 0x4a7a9a, spread: 25 },
+        ];
+        layers.forEach(cfg => {
+            const pos = new Float32Array(cfg.count * 3);
+            for (let i = 0; i < cfg.count * 3; i++) {
+                pos[i] = (Math.random() - 0.5) * cfg.spread;
+            }
+            const geo = new THREE.BufferGeometry();
+            geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+            const mat = new THREE.PointsMaterial({
+                color: cfg.color, size: cfg.size, sizeAttenuation: true,
+            });
+            this.scene.add(new THREE.Points(geo, mat));
+        });
     }
 
+    /* — Floating dust particles (slow orbital drift) — */
+    _createDust() {
+        this.dustGroup = new THREE.Group();
+        this.scene.add(this.dustGroup);
+
+        const count = 300;
+        const pos = new Float32Array(count * 3);
+        const colors = new Float32Array(count * 3);
+
+        for (let i = 0; i < count; i++) {
+            // Distribute within a sphere, biased toward outer shell
+            const r = 2 + Math.random() * 7;
+            const theta = Math.random() * Math.PI * 2;
+            const phi   = Math.acos(2 * Math.random() - 1);
+            pos[i*3]     = r * Math.sin(phi) * Math.cos(theta);
+            pos[i*3 + 1] = r * Math.sin(phi) * Math.sin(theta);
+            pos[i*3 + 2] = r * Math.cos(phi);
+
+            // Random cyan/purple/blue tones
+            const tint = Math.random();
+            if (tint < 0.4) {        // cyan
+                colors[i*3] = 0; colors[i*3+1] = 0.6 + Math.random()*0.3; colors[i*3+2] = 0.5 + Math.random()*0.3;
+            } else if (tint < 0.7) {  // purple
+                colors[i*3] = 0.4 + Math.random()*0.2; colors[i*3+1] = 0.3; colors[i*3+2] = 0.6 + Math.random()*0.3;
+            } else {                   // blue
+                colors[i*3] = 0.1; colors[i*3+1] = 0.2 + Math.random()*0.2; colors[i*3+2] = 0.6 + Math.random()*0.3;
+            }
+        }
+
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+        const mat = new THREE.PointsMaterial({
+            size: 0.035, vertexColors: true, sizeAttenuation: true,
+            transparent: true, opacity: 0.6,
+        });
+        this.dustGroup.add(new THREE.Points(geo, mat));
+    }
+
+    /* — Layered central glow (additive-blend spheres) — */
+    _createCentralGlow() {
+        const shells = [
+            { r: 0.9, color: 0x00d4aa, opacity: 0.05 },
+            { r: 1.6, color: 0xff8c00, opacity: 0.025 },
+            { r: 2.6, color: 0x8b7cc8, opacity: 0.018 },
+            { r: 4.0, color: 0x0a1a3a, opacity: 0.012 },
+        ];
+        shells.forEach(cfg => {
+            const geo = new THREE.SphereGeometry(cfg.r, 20, 20);
+            const mat = new THREE.MeshBasicMaterial({
+                color: cfg.color, transparent: true, opacity: cfg.opacity,
+                side: THREE.BackSide, depthWrite: false,
+            });
+            this.scene.add(new THREE.Mesh(geo, mat));
+        });
+    }
+
+    /* — Central Lain presence (wireframe icosahedron + glow) — */
     _createLainNode() {
-        // Outer wireframe icosahedron
-        const icoGeo = new THREE.IcosahedronGeometry(0.85, 1);
+        // Wireframe icosahedron — Lain's digital shell
+        const icoGeo = new THREE.IcosahedronGeometry(0.75, 1);
         const icoMat = new THREE.MeshBasicMaterial({
-            color: 0x00d4aa,
-            wireframe: true,
-            transparent: true,
-            opacity: 0.55,
+            color: 0x00d4aa, wireframe: true,
+            transparent: true, opacity: 0.45,
         });
         this.lainMesh = new THREE.Mesh(icoGeo, icoMat);
         this.scene.add(this.lainMesh);
 
-        // Inner dark sphere
-        const innerGeo = new THREE.SphereGeometry(0.6, 16, 16);
-        const innerMat = new THREE.MeshBasicMaterial({ color: 0x020212 });
+        // Inner dark core
+        const innerGeo = new THREE.SphereGeometry(0.45, 16, 16);
+        const innerMat = new THREE.MeshBasicMaterial({ color: 0x020210 });
         this.lainInner = new THREE.Mesh(innerGeo, innerMat);
         this.scene.add(this.lainInner);
 
-        // Outer glow shell
-        const glowGeo = new THREE.SphereGeometry(1.3, 16, 16);
-        const glowMat = new THREE.MeshBasicMaterial({
-            color: 0x00d4aa,
-            transparent: true,
-            opacity: 0.025,
-            side: THREE.BackSide,
-        });
-        this.scene.add(new THREE.Mesh(glowGeo, glowMat));
+        // Inner bright point (Lain's "spark")
+        const sparkGeo = new THREE.SphereGeometry(0.08, 8, 8);
+        const sparkMat = new THREE.MeshBasicMaterial({ color: 0x00ffcc });
+        this.lainSpark = new THREE.Mesh(sparkGeo, sparkMat);
+        this.scene.add(this.lainSpark);
 
-        // Second (orange) glow shell
-        const glow2Geo = new THREE.SphereGeometry(1.6, 16, 16);
-        const glow2Mat = new THREE.MeshBasicMaterial({
-            color: 0xff8c00,
-            transparent: true,
-            opacity: 0.01,
-            side: THREE.BackSide,
+        // Close glow shell — cyan
+        const g1 = new THREE.SphereGeometry(1.1, 16, 16);
+        const m1 = new THREE.MeshBasicMaterial({
+            color: 0x00d4aa, transparent: true, opacity: 0.04,
+            side: THREE.BackSide, depthWrite: false,
         });
-        this.scene.add(new THREE.Mesh(glow2Geo, glow2Mat));
+        this.scene.add(new THREE.Mesh(g1, m1));
+
+        // Mid glow shell — orange
+        const g2 = new THREE.SphereGeometry(1.6, 16, 16);
+        const m2 = new THREE.MeshBasicMaterial({
+            color: 0xff8c00, transparent: true, opacity: 0.018,
+            side: THREE.BackSide, depthWrite: false,
+        });
+        this.scene.add(new THREE.Mesh(g2, m2));
     }
 
+    /* — Two gyroscope orbital rings — */
     _createOrbitalRings() {
-        const configs = [
-            { a: [Math.PI/2.2, 0, 0],        color: 0xff8c00, opacity: 0.22, r: 3.0 },
-            { a: [Math.PI/2.2, Math.PI/4, 0], color: 0x00d4aa, opacity: 0.18, r: 3.2 },
-            { a: [0.5, 0, Math.PI/5],          color: 0x8b7cc8, opacity: 0.12, r: 2.8 },
-        ];
-        this.rings = configs.map(cfg => {
-            const geo = new THREE.TorusGeometry(cfg.r, 0.012, 6, 90);
-            const mat = new THREE.MeshBasicMaterial({
-                color: cfg.color, transparent: true, opacity: cfg.opacity,
-            });
-            const mesh = new THREE.Mesh(geo, mat);
-            mesh.rotation.set(...cfg.a);
-            this.scene.add(mesh);
-            return { mesh };
+        const R_A = 3.5;
+        const R_B = 3.2;
+
+        // ── Ring A (primary — holds nav nodes) ──────────────
+        this.ringGroupA = new THREE.Group();
+        this.ringGroupA.rotation.x = Math.PI / 2.2;
+        this.scene.add(this.ringGroupA);
+
+        // Main ring
+        const geoA = new THREE.TorusGeometry(R_A, 0.018, 8, 120);
+        const matA = new THREE.MeshBasicMaterial({
+            color: 0xff8c00, transparent: true, opacity: 0.35,
         });
+        this.ringGroupA.add(new THREE.Mesh(geoA, matA));
+
+        // Glow ring companion
+        const geoAG = new THREE.TorusGeometry(R_A, 0.09, 8, 120);
+        const matAG = new THREE.MeshBasicMaterial({
+            color: 0xff8c00, transparent: true, opacity: 0.04,
+            depthWrite: false,
+        });
+        this.ringGroupA.add(new THREE.Mesh(geoAG, matAG));
+
+        // ── Ring B (secondary — visual gyroscope accent) ────
+        this.ringGroupB = new THREE.Group();
+        this.ringGroupB.rotation.set(Math.PI / 2.6, Math.PI / 3, 0);
+        this.scene.add(this.ringGroupB);
+
+        const geoB = new THREE.TorusGeometry(R_B, 0.014, 8, 120);
+        const matB = new THREE.MeshBasicMaterial({
+            color: 0x00d4aa, transparent: true, opacity: 0.28,
+        });
+        this.ringGroupB.add(new THREE.Mesh(geoB, matB));
+
+        // Glow companion
+        const geoBG = new THREE.TorusGeometry(R_B, 0.07, 8, 120);
+        const matBG = new THREE.MeshBasicMaterial({
+            color: 0x00d4aa, transparent: true, opacity: 0.03,
+            depthWrite: false,
+        });
+        this.ringGroupB.add(new THREE.Mesh(geoBG, matBG));
+
+        // ── Ring C (faint purple accent) ────────────────────
+        const ringC = new THREE.Group();
+        ringC.rotation.set(0.6, 0, Math.PI / 4);
+        this.scene.add(ringC);
+
+        const geoC = new THREE.TorusGeometry(2.9, 0.008, 6, 100);
+        const matC = new THREE.MeshBasicMaterial({
+            color: 0x8b7cc8, transparent: true, opacity: 0.15,
+        });
+        ringC.add(new THREE.Mesh(geoC, matC));
+
+        this.ringC = ringC;
     }
 
+    /* — Navigation spheres (on Ring A) — */
     _createNavNodes() {
         this.navMeshes = [];
-        const R = 3.0;          // orbit radius
-        const tilt = Math.PI / 2.2; // ring tilt angle (must match primary ring)
+        const R = 3.5;
 
-        this.navDefs.forEach((def, i) => {
-            // Sphere node
-            const geo  = new THREE.SphereGeometry(0.22, 14, 14);
-            const mat  = new THREE.MeshBasicMaterial({
-                color: def.color, transparent: true, opacity: 0.85,
+        this.navDefs.forEach((def) => {
+            // Translucent sphere
+            const geo = new THREE.SphereGeometry(0.28, 16, 16);
+            const mat = new THREE.MeshBasicMaterial({
+                color: def.color, transparent: true, opacity: 0.8,
             });
             const mesh = new THREE.Mesh(geo, mat);
-            mesh.userData = { navId: def.id, baseOpacity: 0.85, color: def.color, idx: i };
-            this.scene.add(mesh);
-            this.navMeshes.push(mesh);
+            mesh.userData = { navId: def.id, baseOpacity: 0.8, color: def.color };
 
-            // Halo ring around node
-            const hGeo = new THREE.SphereGeometry(0.38, 12, 12);
+            // Glow halo (BackSide sphere)
+            const hGeo = new THREE.SphereGeometry(0.48, 12, 12);
             const hMat = new THREE.MeshBasicMaterial({
-                color: def.color, transparent: true, opacity: 0.08, side: THREE.BackSide,
+                color: def.color, transparent: true, opacity: 0.1,
+                side: THREE.BackSide, depthWrite: false,
             });
             const halo = new THREE.Mesh(hGeo, hMat);
-            this.scene.add(halo);
             mesh.userData.halo = halo;
+
+            // Add to Ring A group so they rotate with the ring
+            this.ringGroupA.add(mesh);
+            this.ringGroupA.add(halo);
+            this.navMeshes.push(mesh);
 
             // HTML label (from existing DOM element)
             const labelEl = this.labelsEl.querySelector(`[data-target="${def.id}"]`);
@@ -190,15 +302,19 @@ class OrbitalNav {
     }
 
     _createLighting() {
-        this.scene.add(new THREE.AmbientLight(0xffffff, 0.08));
+        this.scene.add(new THREE.AmbientLight(0xffffff, 0.05));
 
-        const orangeL = new THREE.PointLight(0xff8c00, 0.6, 18);
-        orangeL.position.set(4, 2, 1);
+        const orangeL = new THREE.PointLight(0xff8c00, 0.9, 22);
+        orangeL.position.set(5, 3, 2);
         this.scene.add(orangeL);
 
-        const cyanL = new THREE.PointLight(0x00d4aa, 0.6, 18);
-        cyanL.position.set(-4, -1, -2);
+        const cyanL = new THREE.PointLight(0x00d4aa, 0.9, 22);
+        cyanL.position.set(-5, -2, -3);
         this.scene.add(cyanL);
+
+        const purpleL = new THREE.PointLight(0x8b7cc8, 0.4, 15);
+        purpleL.position.set(0, -4, 3);
+        this.scene.add(purpleL);
     }
 
     // ── Events ────────────────────────────────────────────────
@@ -234,54 +350,74 @@ class OrbitalNav {
     // ── Render loop ───────────────────────────────────────────
 
     _renderLoop() {
+        const R = 3.5;
+
         const loop = () => {
             if (!this.running) return;
             requestAnimationFrame(loop);
 
             const t = this.clock.getElapsedTime();
-            const R = 3.0;
-            const tilt = Math.PI / 2.2;
 
-            // Animate Lain central node
+            // ── Animate central Lain node ──
             if (this.lainMesh) {
-                this.lainMesh.rotation.y = t * 0.28;
-                this.lainMesh.rotation.x = Math.sin(t * 0.18) * 0.18;
-                const s = 1 + Math.sin(t * 0.9) * 0.04;
+                this.lainMesh.rotation.y = t * 0.25;
+                this.lainMesh.rotation.x = Math.sin(t * 0.15) * 0.2;
+                const s = 1 + Math.sin(t * 0.8) * 0.05;
                 this.lainMesh.scale.setScalar(s);
             }
+            // Spark pulse
+            if (this.lainSpark) {
+                const sp = 0.06 + Math.sin(t * 2.5) * 0.04;
+                this.lainSpark.scale.setScalar(sp / 0.08);
+            }
 
-            // Slowly rotate rings
-            if (this.rings[0]) this.rings[0].mesh.rotation.z = t * 0.04;
-            if (this.rings[1]) this.rings[1].mesh.rotation.y = t * 0.028;
-            if (this.rings[2]) this.rings[2].mesh.rotation.x += 0.0015;
+            // ── Gyroscope ring rotation ──
+            if (this.ringGroupA) {
+                this.ringGroupA.rotation.z = t * 0.07;
+            }
+            if (this.ringGroupB) {
+                this.ringGroupB.rotation.z = t * 0.05;
+                this.ringGroupB.rotation.x += 0.0008;
+            }
+            if (this.ringC) {
+                this.ringC.rotation.y += 0.0012;
+            }
 
-            // Orbit nav meshes — position + base pulse scale
+            // ── Dust particle drift ──
+            if (this.dustGroup) {
+                this.dustGroup.rotation.y = t * 0.012;
+                this.dustGroup.rotation.x = Math.sin(t * 0.08) * 0.05;
+            }
+
+            // ── Orbit nav nodes along Ring A (in local space) ──
             this.navMeshes.forEach((mesh, i) => {
-                const base  = this.navDefs[i].baseAngle;
-                const angle = base + t * 0.14;
+                const angle = this.navDefs[i].baseAngle + t * 0.12;
                 mesh.position.set(
                     R * Math.cos(angle),
-                    R * Math.sin(angle) * Math.cos(tilt),
-                    R * Math.sin(angle) * Math.sin(tilt) * 0.28
+                    R * Math.sin(angle),
+                    0
                 );
-                if (mesh.userData.halo) mesh.userData.halo.position.copy(mesh.position);
+                if (mesh.userData.halo) {
+                    mesh.userData.halo.position.copy(mesh.position);
+                }
 
-                // Store base pulse scale — hover may multiply it
-                mesh.userData.pulseScale = 1 + Math.sin(t * 1.8 + i * 1.2) * 0.1;
+                // Base pulse scale
+                mesh.userData.pulseScale = 1 + Math.sin(t * 1.8 + i * 1.2) * 0.12;
             });
 
-            // Reset all nodes to default appearance
+            // ── Reset all nav nodes to default ──
             this.navMeshes.forEach(m => {
                 m.material.opacity = m.userData.baseOpacity;
                 m.material.color.setHex(m.userData.color);
                 m.scale.setScalar(m.userData.pulseScale);
                 if (m.userData.halo) {
-                    m.userData.halo.material.opacity = 0.08;
+                    m.userData.halo.material.opacity = 0.1;
                     m.userData.halo.material.color.setHex(m.userData.color);
+                    m.userData.halo.scale.setScalar(1);
                 }
             });
 
-            // Raycaster hover detection
+            // ── Raycaster hover detection ──
             this.raycaster.setFromCamera(this.mouse, this.camera);
             const hits = this.raycaster.intersectObjects(this.navMeshes);
 
@@ -289,11 +425,12 @@ class OrbitalNav {
             if (hits.length > 0) {
                 const h = hits[0].object;
                 h.material.opacity = 1.0;
-                h.material.color.setHex(0x00d4aa);       // cyan on hover
-                h.scale.setScalar(h.userData.pulseScale * 1.3); // 1.3x scale
+                h.material.color.setHex(0xffffff);
+                h.scale.setScalar(h.userData.pulseScale * 1.5);
                 if (h.userData.halo) {
-                    h.userData.halo.material.opacity = 0.3;
+                    h.userData.halo.material.opacity = 0.35;
                     h.userData.halo.material.color.setHex(0x00d4aa);
+                    h.userData.halo.scale.setScalar(1.3);
                 }
                 this.hoveredId = h.userData.navId;
                 this.canvas.style.cursor = 'pointer';
@@ -318,7 +455,9 @@ class OrbitalNav {
             const el = this.labelEls[id];
             if (!el) return;
 
-            const pos = mesh.position.clone().project(this.camera);
+            // Get world position (mesh is inside ringGroupA)
+            mesh.getWorldPosition(this._worldPos);
+            const pos = this._worldPos.clone().project(this.camera);
 
             // Behind camera — hide
             if (pos.z > 1) {
@@ -331,9 +470,12 @@ class OrbitalNav {
             const sy = (-pos.y + 1) / 2 * H;
 
             el.style.left = sx + 'px';
-            el.style.top  = (sy + 30) + 'px';  // offset below the sphere
+            el.style.top  = (sy + 28) + 'px';
 
-            // Highlight on hover
+            // Depth-based opacity (nodes behind center are dimmer)
+            const depth = Math.max(0.35, Math.min(1, 1 - pos.z * 0.6));
+            el.style.opacity = depth;
+
             el.classList.toggle('hovered', this.hoveredId === id);
         });
     }


### PR DESCRIPTION
## Summary

Complete hub screen redesign to match Serial Experiments Lain PSX game (1998) aesthetic:

- **Lain SVG silhouette**: inline dark figure with bob-cut hair, glowing cyan outline, multi-layered `drop-shadow` glow, subtle floating animation — centered above the "L A I N" text
- **Gyroscope orbital rings**: two tilted torus rings rotating on independent axes creating a gyroscope effect. Orange primary ring holds all 7 nav nodes; cyan secondary ring is visual accent. Faint purple third ring for depth.
- **Ring glow companions**: each ring has a thick transparent torus halo for volumetric glow
- **Enhanced nav spheres**: 0.28r (up from 0.22r), translucent with BackSide glow halos, white flash + 1.5x scale on hover, depth-based label opacity (nodes behind center fade)
- **3-layer star field**: 1850 particles across background/mid/foreground depths for parallax
- **300 floating dust particles**: orbital drift, vertex-colored in cyan/purple/blue tones
- **Layered central glow**: 4 additive-blend BackSide spheres (cyan→orange→purple→void)
- **Lain wireframe icosahedron**: retained as subtle digital shell behind SVG, with inner spark pulse
- **Enhanced lighting**: 3 colored point lights (orange, cyan, purple) for dramatic atmosphere
- **Nav label color coding**: per-screen border/hover colors (tasks=green, search=pink, wired=yellow)

## Test plan

- [ ] Hub screen shows Lain SVG silhouette centered with cyan glow
- [ ] Two orbital rings rotate like a gyroscope (different axes)
- [ ] All 7 nav spheres orbit on the primary ring and are clickable
- [ ] Hover effect: sphere turns white, scales 1.5x, halo brightens
- [ ] Dust particles drift slowly in background
- [ ] Central wireframe icosahedron rotates behind silhouette
- [ ] Deep void feeling: dark background, atmospheric fog, star layers
- [ ] Nav labels fade based on depth (behind-camera nodes hidden)
- [ ] No console errors
- [ ] Mobile touch navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)