### PR TITLE
feat: DIARY session info panel + reset (#64)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -554,7 +554,16 @@ async def api_search(q: str = ""):
 
 @app.get("/api/session")
 async def api_session():
-    return JSONResponse({"sessionId": gateway.get_current_session_id()})
+    return JSONResponse({
+        "sessionId": gateway.get_current_session_id(),
+        "message_count": len(load_diary_history()),
+    })
+
+
+@app.post("/api/session/reset")
+async def api_session_reset():
+    gateway.reset_session()
+    return JSONResponse({"ok": True})
 
 
 # ── WIRED feed ────────────────────────────────────────────────────────────────

--- a/frontend/js/chat.js
+++ b/frontend/js/chat.js
@@ -40,6 +40,7 @@ class IwakuraChat {
         this.container = container;
         this._restoreHistory();
         this._connect();
+        this._initSessionBar();
 
         // Auto-scroll: track when user scrolls up
         if (container) {
@@ -77,8 +78,26 @@ class IwakuraChat {
     }
 
     resetSession() {
-        if (!this.connected) return;
-        this._send({ type: 'reset_session' });
+        fetch('/api/session/reset', { method: 'POST' }).catch(() => {});
+        this._addSysMsg('SESSION RESET — NEW CONNECTION ESTABLISHED');
+        this._addSepMsg('NEW SESSION');
+        if (this.onSessionChange) this.onSessionChange(null);
+        // Reconnect WebSocket
+        if (this.ws) { this.ws.onclose = null; this.ws.close(); }
+        this.connected = false;
+        this._stopPing();
+        if (this.onStatusChange) this.onStatusChange(false);
+        this.reconnectMs = 2000;
+        this._connect();
+    }
+
+    _initSessionBar() {
+        // Load current session from REST and surface it via onSessionChange
+        fetch('/api/session').then(r => r.json()).then(data => {
+            if (data.sessionId && this.onSessionChange) {
+                this.onSessionChange(data.sessionId);
+            }
+        }).catch(() => {});
     }
 
     // ── Connection ────────────────────────────────────────────

--- a/frontend/js/diary.js
+++ b/frontend/js/diary.js
@@ -461,11 +461,29 @@
 
     inputEl.addEventListener('input', updateTagPreview);
 
-    resetBtn.addEventListener('click', () => {
-        if (connected) send({ type: 'reset_session' });
+    resetBtn.addEventListener('click', async () => {
+        try {
+            await fetch('/api/session/reset', { method: 'POST' });
+        } catch (_) {}
+        addMsg('sys', 'SESSION RESET — NEW CONNECTION ESTABLISHED');
+        if (sessLabel) sessLabel.textContent = 'SESSION: --';
+        // Reconnect WebSocket
+        if (ws) { ws.onclose = null; ws.close(); }
+        connected = false;
+        stopPing();
+        setStatus(false);
+        reconnectMs = 2000;
+        connect();
     });
 
     // ── Boot ──────────────────────────────────────────────────
+    // Load initial session info
+    fetch('/api/session').then(r => r.json()).then(data => {
+        if (data.sessionId && sessLabel) {
+            sessLabel.textContent = 'SESSION: ' + data.sessionId.slice(0, 8) + '...';
+        }
+    }).catch(() => {});
+
     loadHistory().then(() => connect());
 
 })();


### PR DESCRIPTION
## Summary

- `GET /api/session` now returns `{sessionId, message_count}` (was missing `message_count`)
- `POST /api/session/reset` — new endpoint that calls `gateway.reset_session()` and returns `{ok: true}`
- `chat.js`: `_initSessionBar()` fetches `/api/session` on init and surfaces `sessionId` via the existing `onSessionChange` callback (populates `#diary-session-label` in both SPA and standalone diary)
- `chat.js`: `resetSession()` now calls `POST /api/session/reset` + reconnects WebSocket instead of sending a WS message
- `diary.js`: reset button calls `POST /api/session/reset` then reconnects WebSocket
- `diary.js`: loads initial session label from `GET /api/session` on boot

Closes #64