### PR TITLE
fix: 3D hub broken — canvas hidden, LAIN text garbled (#68)

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -135,7 +135,9 @@ body::after {
 }
 
 /* ── Hub Screen ────────────────────────────────────────────── */
-#screen-hub { position: relative; }
+/* NOTE: #screen-hub intentionally inherits position:absolute;inset:0 from
+   .screen — do NOT add position:relative here; that collapses the element
+   to 0px height and hides the Three.js canvas entirely. */
 #hub-canvas {
     position: absolute; inset: 0;
     width: 100%; height: 100%;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -99,7 +99,7 @@
                     <line x1="66" y1="74" x2="76" y2="74" stroke="#00d4aa" stroke-width="0.7" opacity="0.3"/>
                 </svg>
             </div>
-            <div class="center-name" data-glitch>L A I N</div>
+            <div class="center-name">L A I N</div>
             <div class="center-status" id="hub-lain-status">● PRESENT</div>
         </div>
         <div class="hub-footer">


### PR DESCRIPTION
## Root Cause

Two bugs introduced in PR #63 (PSX 3D overhaul):

### Bug 1 — Hub collapses to 0px height (P0)

```css
/* PR #63 added this: */
#screen-hub { position: relative; }
```

This ID-selector overrides the class-selector rule `.screen { position: absolute; inset: 0; }` (ID > class specificity). The result: `#screen-hub` becomes `position: relative` with no explicit width/height. Since **all** its children are `position: absolute`, they're removed from flow and the hub div collapses to **0px height**. The Three.js canvas (`width: 100%; height: 100%` of a 0px parent) becomes invisible. Nav labels have no containing-block height, so they pile at the top-left corner.

**Fix:** Remove the `position: relative` rule. `.screen` already provides `position: absolute; inset: 0` which also serves as a containing block for absolutely-positioned children.

### Bug 2 — "L A I N" corrupted to "A 7 , N"

```html
<!-- PR #63 added data-glitch here: -->
<div class="center-name" data-glitch>L A I N</div>
```

`app.js` calls `glitchFX.enableTextGlitch('[data-glitch]')` on DOMContentLoaded, which schedules periodic character-corruption on every `[data-glitch]` element. On the hub screen, this corrupts "L A I N" with random katakana/hex characters every 4–12s. Because the restore timeout (80–200ms) could race with re-triggers, the text gets stuck in a corrupted state.

**Fix:** Remove `data-glitch` from `.center-name`. Lain's name should not be scrambled.

## Test plan
- [ ] Hub screen shows 3D orbital rings + nav spheres (no blank canvas)
- [ ] "L A I N" text is stable and readable at center of hub
- [ ] All 7 nav nodes are clickable and navigate correctly
- [ ] Navigating away and back resumes animation without errors

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)