### PR TITLE
feat: animated Lain character

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1293,28 +1293,195 @@ body.flicker { animation: flicker-pulse 100ms forwards; }
 }
 .nav-label-item[data-target="wired"] .nav-label-code { color: #ffcc00; }
 
-/* ── Lain SVG Silhouette ───────────────────────────────────── */
-.lain-silhouette-wrap {
-    width: 90px;
-    height: 150px;
-    margin: 0 auto 12px;
+/* ── Lain Animated Character ───────────────────────────────── */
+
+/* Hub center label is now driven by LainCharacter — holds SVG + nameplate */
+/* The container also has .lain-char-inner for state+blink CSS selectors.   */
+/* Override the base .hub-center-label (line ~228) — transform is baked into
+   the animation keyframes to avoid property conflict.                       */
+.hub-center-label {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: none;   /* will be set by animation keyframes */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
+    user-select: none;
     pointer-events: none;
-    filter:
-        drop-shadow(0 0 6px rgba(0,212,170,0.6))
-        drop-shadow(0 0 18px rgba(0,212,170,0.3))
-        drop-shadow(0 0 40px rgba(0,212,170,0.12));
-    animation: lain-float 7s ease-in-out infinite;
-    opacity: 0.8;
-}
-.lain-svg {
-    width: 100%;
-    height: 100%;
-    display: block;
+    z-index: 2;
+    text-align: center;
 }
 
+/* The SVG character — large focal point */
+.lain-svg {
+    width: clamp(180px, 22vw, 300px);
+    height: auto;
+    display: block;
+    overflow: visible;
+    /* PSX glow: layered cyan drop-shadows */
+    filter:
+        drop-shadow(0 0 6px  rgba(0,212,170,0.5))
+        drop-shadow(0 0 20px rgba(0,212,170,0.22))
+        drop-shadow(0 0 50px rgba(0,212,170,0.08));
+}
+
+/* Nameplate below character */
+.lain-nameplate {
+    text-align: center;
+    margin-top: 10px;
+}
+
+/* ── Animation keyframes ───────────────────────────────────── */
+
+/* Whole character floats gently up/down */
 @keyframes lain-float {
     0%, 100% { transform: translateY(0); }
-    50%      { transform: translateY(-6px); }
+    50%       { transform: translateY(-10px); }
+}
+.lain-float {
+    animation: lain-float 5.5s ease-in-out infinite;
+    transform-origin: 60px 125px;
+}
+
+/* Body breathing: subtle scale + rise */
+@keyframes lain-breathe {
+    0%, 100% { transform: translateY(0)   scaleX(1); }
+    45%       { transform: translateY(-2px) scaleX(1.013); }
+}
+.lain-breathe {
+    animation: lain-breathe 4s ease-in-out infinite;
+    transform-origin: 60px 180px;
+    transform-box: fill-box;
+}
+
+/* Idle sway: translate(-50%,-54%) must be in keyframes to avoid conflict */
+@keyframes lain-idle-sway {
+    0%, 100% { transform: translate(-50%, -54%) rotate(-0.7deg); }
+    50%       { transform: translate(-50%, -54%) rotate(0.7deg); }
+}
+.hub-center-label {
+    animation: lain-idle-sway 8s ease-in-out infinite;
+}
+
+/* Aura glow pulse */
+@keyframes lc-aura-pulse {
+    0%, 100% { opacity: 0.7; }
+    50%       { opacity: 1; }
+}
+.lc-aura { animation: lc-aura-pulse 3.5s ease-in-out infinite; }
+
+/* ── Eyelid blink ─────────────────────────────────────────── */
+/* Lids start invisible (scaleY 0 = flat = eye open) */
+.lc-lid-l, .lc-lid-r,
+.lc-lidline-l, .lc-lidline-r {
+    transform-box: fill-box;
+    transform-origin: 50% 0%;
+    transform: scaleY(0);
+    pointer-events: none;
+}
+
+@keyframes lain-blink-close {
+    0%   { transform: scaleY(0); }
+    40%  { transform: scaleY(1); }
+    65%  { transform: scaleY(1); }
+    100% { transform: scaleY(0); }
+}
+
+/* JS adds/removes .blinking on the container (which has .lain-char-inner class) */
+.lain-char-inner .lc-lid-l,
+.lain-char-inner .lc-lid-r,
+.lain-char-inner .lc-lidline-l,
+.lain-char-inner .lc-lidline-r {
+    transform: scaleY(0);
+}
+.lain-char-inner.blinking .lc-lid-l,
+.lain-char-inner.blinking .lc-lid-r {
+    animation: lain-blink-close 0.22s ease forwards;
+}
+.lain-char-inner.blinking .lc-lidline-l,
+.lain-char-inner.blinking .lc-lidline-r {
+    animation: lain-blink-close 0.22s ease forwards;
+}
+
+/* ── State: idle (default) ─────────────────────────────────── */
+/* Show only idle mouth and normal brows */
+.lain-char-inner .lc-mouth-happy,
+.lain-char-inner .lc-mouth-surprised,
+.lain-char-inner .lc-mouth-thinking,
+.lain-char-inner .lc-mouth-talking-open,
+.lain-char-inner .lc-mouth-talking-closed  { display: none; }
+
+.lain-char-inner .lc-brow-raised,
+.lain-char-inner .lc-brow-furrowed         { display: none; }
+
+/* ── State: happy ──────────────────────────────────────────── */
+.lain-char-inner[data-state="happy"] .lc-mouth-idle    { display: none; }
+.lain-char-inner[data-state="happy"] .lc-mouth-happy   { display: block; }
+.lain-char-inner[data-state="happy"] .lc-blush-l,
+.lain-char-inner[data-state="happy"] .lc-blush-r       { opacity: 0.52 !important; }
+
+/* ── State: surprised ──────────────────────────────────────── */
+.lain-char-inner[data-state="surprised"] .lc-mouth-idle       { display: none; }
+.lain-char-inner[data-state="surprised"] .lc-mouth-surprised  { display: block; }
+.lain-char-inner[data-state="surprised"] .lc-brow-normal      { display: none; }
+.lain-char-inner[data-state="surprised"] .lc-brow-raised      { display: block; }
+/* Eyes wider: scale iris up slightly */
+.lain-char-inner[data-state="surprised"] .lain-eye-l ellipse:nth-child(2),
+.lain-char-inner[data-state="surprised"] .lain-eye-r ellipse:nth-child(2) {
+    transform-box: fill-box;
+    transform-origin: center;
+    transform: scale(1.18);
+}
+
+/* ── State: thinking ──────────────────────────────────────── */
+.lain-char-inner[data-state="thinking"] .lc-mouth-idle     { display: none; }
+.lain-char-inner[data-state="thinking"] .lc-mouth-thinking { display: block; }
+.lain-char-inner[data-state="thinking"] .lc-brow-normal    { display: none; }
+.lain-char-inner[data-state="thinking"] .lc-brow-furrowed  { display: block; }
+/* Head tilts slightly */
+@keyframes lain-think-tilt {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(-9deg); }
+}
+.lain-char-inner[data-state="thinking"] .lain-head {
+    animation: lain-think-tilt 0.5s ease forwards;
+    transform-origin: 60px 115px;
+    transform-box: fill-box;
+}
+
+/* ── State: curious (nav hover) ──────────────────────────── */
+@keyframes lain-curious-tilt {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(-6deg); }
+}
+.lain-char-inner[data-state="curious"] .lain-head {
+    animation: lain-curious-tilt 0.3s ease forwards;
+    transform-origin: 60px 115px;
+    transform-box: fill-box;
+}
+.lain-char-inner[data-state="curious"] .lc-brow-normal { display: none; }
+.lain-char-inner[data-state="curious"] .lc-brow-raised { display: block; }
+
+/* ── State: talking ──────────────────────────────────────── */
+.lain-char-inner[data-state="talking"] .lc-mouth-idle { display: none; }
+/* Mouth open/closed toggled by data-mouth attribute (via JS) */
+.lain-char-inner[data-state="talking"]:not([data-mouth="open"]) .lc-mouth-talking-open   { display: none; }
+.lain-char-inner[data-state="talking"]:not([data-mouth="open"]) .lc-mouth-talking-closed { display: block; }
+.lain-char-inner[data-state="talking"][data-mouth="open"]       .lc-mouth-talking-closed { display: none; }
+.lain-char-inner[data-state="talking"][data-mouth="open"]       .lc-mouth-talking-open   { display: block; }
+
+/* ── Reduced motion overrides ────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+    .lain-float    { animation: none; }
+    .lain-breathe  { animation: none; }
+    .hub-center-label { animation: none; }
+    .lc-aura       { animation: none; }
+    .lain-char-inner.blinking .lc-lid-l,
+    .lain-char-inner.blinking .lc-lid-r,
+    .lain-char-inner.blinking .lc-lidline-l,
+    .lain-char-inner.blinking .lc-lidline-r { animation: none; }
 }
 
 /* ── Hub Visual Enhancements ───────────────────────────────── */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,30 +78,9 @@
             <span class="header-title" data-glitch>THE WIRED // ACCESS POINT</span>
             <span class="header-code green">Ira042</span>
         </div>
-        <div class="hub-center-label">
-            <!-- Lain silhouette — dark figure, glowing outline -->
-            <div class="lain-silhouette-wrap">
-                <svg class="lain-svg" viewBox="0 0 120 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <!-- Hair (bob cut outer) -->
-                    <path d="M60,8 C82,8 100,26 102,52 C104,68 97,84 88,94
-                             C88,44 75,16 60,16 C45,16 32,44 32,94
-                             C23,84 16,68 18,52 C20,26 38,8 60,8Z"
-                          fill="#06061a" stroke="#00d4aa" stroke-width="1.2"/>
-                    <!-- Face + neck + body -->
-                    <path d="M32,94 C32,44 45,16 60,16 C75,16 88,44 88,94
-                             C88,110 80,124 74,130 L74,142
-                             C92,146 110,164 114,190 L114,198 L6,198 L6,190
-                             C10,164 28,146 46,142 L46,130
-                             C40,124 32,110 32,94Z"
-                          fill="#06061a" stroke="#00d4aa" stroke-width="0.9"/>
-                    <!-- Eyes — minimal, mysterious -->
-                    <line x1="44" y1="74" x2="54" y2="74" stroke="#00d4aa" stroke-width="0.7" opacity="0.3"/>
-                    <line x1="66" y1="74" x2="76" y2="74" stroke="#00d4aa" stroke-width="0.7" opacity="0.3"/>
-                </svg>
-            </div>
-            <div class="center-name">L A I N</div>
-            <div class="center-status" id="hub-lain-status">● PRESENT</div>
-        </div>
+        <!-- Lain character — populated by character.js LainCharacter -->
+        <div class="hub-center-label lain-char-inner" id="lain-char-container"
+             data-state="idle"></div>
         <div class="hub-footer">
             <span class="dim">SITE A</span>
             <span class="orange">▸</span>
@@ -291,6 +270,7 @@
 <script src="js/effects.js"></script>
 <script src="js/chat.js"></script>
 <script src="js/nav.js"></script>
+<script src="js/character.js"></script>
 <script src="js/psyche.js"></script>
 <script src="js/memory.js"></script>
 <script src="js/status.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -9,6 +9,7 @@
     // ── State ─────────────────────────────────────────────────
     let currentScreen = 'boot';
     let orbNav        = null;
+    let lainChar      = null;   // LainCharacter instance
     let chat          = null;
     let memory        = null;
     let psyche        = null;
@@ -168,10 +169,26 @@
 
         if (!canvas) return;
 
+        // Init Lain character (once)
+        if (!lainChar) {
+            const charEl = document.getElementById('lain-char-container');
+            if (charEl && window.LainCharacter) {
+                lainChar = new LainCharacter(charEl);
+                lainChar.init();
+            }
+        }
+
         if (!orbNav) {
             orbNav = new OrbitalNav(canvas, labelsDiv, (id) => {
+                if (lainChar) lainChar.onNavigate();
                 showScreen(id);
             });
+            // Wire nav hover → character reactions
+            orbNav.onHoverChange = (navId) => {
+                if (!lainChar) return;
+                if (navId) lainChar.onHoverNav(navId);
+                else       lainChar.onLeaveNav();
+            };
             orbNav.init();
         } else {
             orbNav.resume();

--- a/frontend/js/character.js
+++ b/frontend/js/character.js
@@ -1,0 +1,382 @@
+/* ── LainCharacter ────────────────────────────────────────────────────────────
+   Animated Lain character for the hub screen.
+   Canvas-drawn, PSX-pixelated sprite with multiple emotional states.
+   States: idle | thinking | happy | surprised | curious | talking
+   Animations: floating, breathing, blinking (3–7s random), idle pose (15–30s)
+   ─────────────────────────────────────────────────────────────────────────── */
+
+class LainCharacter {
+    constructor(containerEl) {
+        this._el        = containerEl;
+        this._state     = 'idle';
+        this._blinkTmr  = null;
+        this._poseTmr   = null;
+        this._talkIv    = null;
+        this._mouthOpen = false;
+    }
+
+    init() {
+        this._el.innerHTML = this._buildHTML();
+        this._scheduleBlink();
+        this._schedulePose();
+    }
+
+    setState(state) {
+        if (this._state === state) return;
+        this._state = state;
+        this._el.setAttribute('data-state', state);
+    }
+
+    /* Called by OrbitalNav when user hovers a navigation sphere */
+    onHoverNav(navId) {
+        if (this._state === 'talking' || this._state === 'surprised') return;
+        this.setState('curious');
+    }
+
+    /* Called when hover leaves all nav spheres */
+    onLeaveNav() {
+        if (this._state === 'curious') this.setState('idle');
+    }
+
+    /* Called on screen navigation */
+    onNavigate() {
+        this.setState('surprised');
+        setTimeout(() => {
+            if (this._state === 'surprised') this.setState('idle');
+        }, 1000);
+    }
+
+    /* Called when Lain starts responding (chat) */
+    onTalkStart() {
+        this.setState('talking');
+        this._stopTalk();
+        this._talkIv = setInterval(() => {
+            this._mouthOpen = !this._mouthOpen;
+            this._el.setAttribute('data-mouth', this._mouthOpen ? 'open' : 'closed');
+        }, 220);
+    }
+
+    /* Called when Lain finishes responding */
+    onTalkEnd() {
+        this._stopTalk();
+        this.setState('idle');
+    }
+
+    stop() {
+        if (this._blinkTmr) { clearTimeout(this._blinkTmr); this._blinkTmr = null; }
+        if (this._poseTmr)  { clearTimeout(this._poseTmr);  this._poseTmr  = null; }
+        this._stopTalk();
+    }
+
+    _stopTalk() {
+        if (this._talkIv) { clearInterval(this._talkIv); this._talkIv = null; }
+        this._mouthOpen = false;
+        this._el.removeAttribute('data-mouth');
+    }
+
+    _scheduleBlink() {
+        const delay = 3000 + Math.random() * 4000; // 3–7s
+        this._blinkTmr = setTimeout(() => {
+            this._el.classList.add('blinking');
+            setTimeout(() => this._el.classList.remove('blinking'), 220);
+            this._scheduleBlink();
+        }, delay);
+    }
+
+    _schedulePose() {
+        const delay = 15000 + Math.random() * 15000; // 15–30s
+        this._poseTmr = setTimeout(() => {
+            const poses  = ['thinking', 'happy'];
+            const chosen = poses[Math.floor(Math.random() * poses.length)];
+            this.setState(chosen);
+            setTimeout(() => {
+                if (this._state === chosen) this.setState('idle');
+                this._schedulePose();
+            }, 3000 + Math.random() * 2000);
+        }, delay);
+    }
+
+    // ── SVG + HTML ────────────────────────────────────────────
+
+    _buildHTML() {
+        // Inject directly into this._el (which is already .lain-char-inner + .hub-center-label)
+        return `${this._buildSVG()}
+<div class="lain-nameplate">
+  <div class="center-name" data-glitch>L A I N</div>
+  <div class="center-status" id="hub-lain-status">● PRESENT</div>
+</div>`;
+    }
+
+    _buildSVG() {
+        /* ViewBox: 0 0 120 250
+           Coordinate guide:
+             Bear ears  : (35,22) and (85,22), r=14
+             Hood ellipse: cx=60 cy=70 rx=42 ry=50
+             Face oval  : cx=60 cy=70 rx=25 ry=28
+             Eyes       : L(46,63) R(74,63)
+             Mouth      : y≈85
+             Neck       : y≈98–112
+             Body       : y=108–240
+             Arms       : sides of body
+        */
+        return `<svg class="lain-svg" viewBox="0 0 120 250"
+     xmlns="http://www.w3.org/2000/svg" overflow="visible" aria-label="Lain">
+  <defs>
+    <!-- Face gradient: warm pale skin with slight blush toward cheeks -->
+    <radialGradient id="lc-face" cx="45%" cy="38%" r="68%">
+      <stop offset="0%"   stop-color="#faeee0"/>
+      <stop offset="100%" stop-color="#e8d4c0"/>
+    </radialGradient>
+    <!-- Hood / onesie: gray-purple PSX palette -->
+    <radialGradient id="lc-hood" cx="35%" cy="22%" r="80%">
+      <stop offset="0%"   stop-color="#cccce0"/>
+      <stop offset="100%" stop-color="#9898b8"/>
+    </radialGradient>
+    <!-- Inner ear: dusty pink -->
+    <radialGradient id="lc-ear-inner" cx="50%" cy="50%" r="70%">
+      <stop offset="0%"   stop-color="#d4a8b8"/>
+      <stop offset="100%" stop-color="#b888a0"/>
+    </radialGradient>
+    <!-- Eye iris: deep navy-blue (PSX Lain color) -->
+    <radialGradient id="lc-iris" cx="38%" cy="32%" r="70%">
+      <stop offset="0%"   stop-color="#5a6a9a"/>
+      <stop offset="100%" stop-color="#28385a"/>
+    </radialGradient>
+    <!-- Ambient glow around full character -->
+    <radialGradient id="lc-aura" cx="50%" cy="55%" r="50%">
+      <stop offset="0%"   stop-color="#00d4aa" stop-opacity="0.16"/>
+      <stop offset="55%"  stop-color="#00d4aa" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#00d4aa" stop-opacity="0"/>
+    </radialGradient>
+    <!-- Drop shadow for depth -->
+    <filter id="lc-shadow" x="-20%" y="-10%" width="140%" height="130%">
+      <feDropShadow dx="0" dy="3" stdDeviation="4" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+    <!-- CRT color slight shift for PSX vibe -->
+    <filter id="lc-psx" color-interpolation-filters="sRGB">
+      <feColorMatrix type="matrix"
+        values="0.94 0.04 0.04 0 0.01
+                0.02 0.93 0.03 0 0
+                0.04 0.03 1.06 0 0
+                0    0    0    1 0"/>
+    </filter>
+  </defs>
+
+  <!-- ── AMBIENT GLOW ─────────────────────────────────────── -->
+  <ellipse class="lc-aura" cx="60" cy="170" rx="54" ry="82" fill="url(#lc-aura)"/>
+
+  <!-- ── FLOATING + BREATHING WRAPPER ─────────────────────── -->
+  <g class="lain-float">
+    <g class="lain-breathe" filter="url(#lc-psx)">
+
+      <!-- ── BODY (drawn before head so head renders on top) ── -->
+      <!-- Main onesie torso -->
+      <path class="lc-body"
+            d="M26,118 Q14,130 12,195 L12,245 Q14,252 30,252
+               L30,240 Q32,230 46,228 L46,230 Q48,232 60,232
+               Q72,232 74,230 L74,228 Q88,230 90,240
+               L90,252 Q106,252 108,245 L108,195
+               Q106,130 94,118 Q78,110 60,110 Q42,110 26,118 Z"
+            fill="url(#lc-hood)"/>
+
+      <!-- Subtle belly/chest shading -->
+      <ellipse cx="60" cy="160" rx="28" ry="32"
+               fill="rgba(0,0,0,0.06)"/>
+
+      <!-- Onesie center zip seam -->
+      <line x1="60" y1="118" x2="60" y2="232"
+            stroke="#8888a8" stroke-width="0.6"
+            stroke-dasharray="2.5,4" opacity="0.6"/>
+
+      <!-- Paw print on chest (left, bear branding) -->
+      <g class="lc-pawprint" opacity="0.4" transform="translate(35,152)">
+        <ellipse cx="0" cy="0" rx="5.5" ry="4.5" fill="#7878a0"/>
+        <circle cx="-4"  cy="-6" r="2.4" fill="#7878a0"/>
+        <circle cx="0"   cy="-7" r="2.4" fill="#7878a0"/>
+        <circle cx="4"   cy="-6" r="2.4" fill="#7878a0"/>
+        <circle cx="-6"  cy="-2" r="1.8" fill="#7878a0"/>
+        <circle cx="6"   cy="-2" r="1.8" fill="#7878a0"/>
+      </g>
+
+      <!-- LEFT ARM -->
+      <path d="M26,118 Q10,132 8,182 Q8,194 18,198
+               L28,198 Q36,194 38,184 L40,126 Z"
+            fill="url(#lc-hood)"/>
+      <!-- Left paw hand -->
+      <g transform="translate(17,200)">
+        <ellipse cx="0" cy="0" rx="11" ry="7.5" fill="#bbbbd0"/>
+        <circle cx="-5"  cy="-6" r="3.2" fill="#aaaac0"/>
+        <circle cx="0"   cy="-7" r="3.2" fill="#aaaac0"/>
+        <circle cx="5"   cy="-6" r="3.2" fill="#aaaac0"/>
+        <circle cx="-8"  cy="-2" r="2.4" fill="#aaaac0"/>
+        <circle cx="8"   cy="-2" r="2.4" fill="#aaaac0"/>
+      </g>
+
+      <!-- RIGHT ARM -->
+      <path d="M94,118 Q110,132 112,182 Q112,194 102,198
+               L92,198 Q84,194 82,184 L80,126 Z"
+            fill="url(#lc-hood)"/>
+      <!-- Right paw hand -->
+      <g transform="translate(103,200)">
+        <ellipse cx="0" cy="0" rx="11" ry="7.5" fill="#bbbbd0"/>
+        <circle cx="-5"  cy="-6" r="3.2" fill="#aaaac0"/>
+        <circle cx="0"   cy="-7" r="3.2" fill="#aaaac0"/>
+        <circle cx="5"   cy="-6" r="3.2" fill="#aaaac0"/>
+        <circle cx="-8"  cy="-2" r="2.4" fill="#aaaac0"/>
+        <circle cx="8"   cy="-2" r="2.4" fill="#aaaac0"/>
+      </g>
+
+      <!-- FEET (barely peeking out, PSX style) -->
+      <ellipse cx="42" cy="249" rx="16" ry="7" fill="#a8a8c0"/>
+      <ellipse cx="78" cy="249" rx="16" ry="7" fill="#a8a8c0"/>
+
+      <!-- ── HEAD GROUP (rotates for thinking/curious) ──────── -->
+      <g class="lain-head">
+
+        <!-- Neck -->
+        <path d="M50,110 Q50,104 60,102 Q70,104 70,110
+                 L70,120 Q70,122 60,122 Q50,122 50,120 Z"
+              fill="#e8d4c0"/>
+
+        <!-- Bear ears (behind hood) -->
+        <circle cx="33"  cy="26" r="16" fill="url(#lc-hood)"/>
+        <circle cx="33"  cy="26" r="9"  fill="url(#lc-ear-inner)"/>
+        <circle cx="87" cy="26" r="16" fill="url(#lc-hood)"/>
+        <circle cx="87" cy="26" r="9"  fill="url(#lc-ear-inner)"/>
+
+        <!-- Hood outer shape -->
+        <ellipse cx="60" cy="70" rx="44" ry="52" fill="url(#lc-hood)"/>
+        <!-- Hood rim shadow at bottom -->
+        <ellipse cx="60" cy="80" rx="38" ry="44" fill="rgba(0,0,0,0.07)"/>
+
+        <!-- FACE -->
+        <ellipse cx="60" cy="70" rx="27" ry="31" fill="url(#lc-face)"/>
+
+        <!-- Cheek blush (soft, always present, intensifies on happy) -->
+        <ellipse class="lc-blush-l" cx="40" cy="78" rx="9"  ry="5.5"
+                 fill="#ffb0c0" opacity="0.28"/>
+        <ellipse class="lc-blush-r" cx="80" cy="78" rx="9"  ry="5.5"
+                 fill="#ffb0c0" opacity="0.28"/>
+
+        <!-- EYEBROWS -->
+        <g class="lain-brows">
+          <!-- Left brow (normal) -->
+          <path class="lc-brow-l lc-brow-normal"
+                d="M37,55 Q45,50 53,53"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <!-- Right brow (normal) -->
+          <path class="lc-brow-r lc-brow-normal"
+                d="M67,53 Q75,50 83,55"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <!-- Left brow (raised — surprised/curious) -->
+          <path class="lc-brow-l lc-brow-raised"
+                d="M37,51 Q45,46 53,49"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <!-- Right brow (raised) -->
+          <path class="lc-brow-r lc-brow-raised"
+                d="M67,49 Q75,46 83,51"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <!-- Left brow (furrowed — thinking/sad) -->
+          <path class="lc-brow-l lc-brow-furrowed"
+                d="M38,56 Q46,53 54,56"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <!-- Right brow (furrowed — thinking/sad) -->
+          <path class="lc-brow-r lc-brow-furrowed"
+                d="M66,56 Q74,53 82,56"
+                stroke="#4a2e18" stroke-width="2" stroke-linecap="round" fill="none"/>
+        </g>
+
+        <!-- ── EYES ─────────────────────────────────────────── -->
+        <!-- LEFT EYE -->
+        <g class="lain-eye-l" filter="url(#lc-shadow)">
+          <!-- Sclera (white) -->
+          <ellipse cx="46" cy="64" rx="10" ry="10.5" fill="#f8f8ff"/>
+          <!-- Iris -->
+          <ellipse cx="46" cy="64" rx="7"  ry="7.5"  fill="url(#lc-iris)"/>
+          <!-- Pupil -->
+          <ellipse cx="46" cy="64" rx="4"  ry="4.5"  fill="#06060f"/>
+          <!-- Main catchlight -->
+          <ellipse cx="43" cy="60" rx="2.2" ry="2.2" fill="#ffffff"/>
+          <!-- Secondary catchlight -->
+          <ellipse cx="48" cy="67" rx="1"   ry="1"   fill="#ffffff" opacity="0.6"/>
+          <!-- Eyelid top line -->
+          <path d="M36,61 Q46,55 56,61"
+                stroke="#1a0808" stroke-width="1.4" fill="none"/>
+          <!-- Eyelid lower line -->
+          <path d="M37,67 Q46,73 55,67"
+                stroke="#3a1818" stroke-width="0.8" fill="none" opacity="0.6"/>
+        </g>
+        <!-- Left eyelid (blink overlay — scaleY 0→1 from top) -->
+        <ellipse class="lc-lid-l"
+                 cx="46" cy="64" rx="10.5" ry="10.5"
+                 fill="url(#lc-face)"/>
+        <!-- Left closed-eye line (visible when blinking) -->
+        <path class="lc-lidline-l"
+              d="M36,64 Q46,70 56,64"
+              stroke="#2a1010" stroke-width="1.2" fill="none"/>
+
+        <!-- RIGHT EYE -->
+        <g class="lain-eye-r" filter="url(#lc-shadow)">
+          <ellipse cx="74" cy="64" rx="10" ry="10.5" fill="#f8f8ff"/>
+          <ellipse cx="74" cy="64" rx="7"  ry="7.5"  fill="url(#lc-iris)"/>
+          <ellipse cx="74" cy="64" rx="4"  ry="4.5"  fill="#06060f"/>
+          <ellipse cx="71" cy="60" rx="2.2" ry="2.2" fill="#ffffff"/>
+          <ellipse cx="76" cy="67" rx="1"   ry="1"   fill="#ffffff" opacity="0.6"/>
+          <path d="M64,61 Q74,55 84,61"
+                stroke="#1a0808" stroke-width="1.4" fill="none"/>
+          <path d="M65,67 Q74,73 83,67"
+                stroke="#3a1818" stroke-width="0.8" fill="none" opacity="0.6"/>
+        </g>
+        <!-- Right eyelid -->
+        <ellipse class="lc-lid-r"
+                 cx="74" cy="64" rx="10.5" ry="10.5"
+                 fill="url(#lc-face)"/>
+        <path class="lc-lidline-r"
+              d="M64,64 Q74,70 84,64"
+              stroke="#2a1010" stroke-width="1.2" fill="none"/>
+
+        <!-- NOSE (subtle two-dot + bridge) -->
+        <path d="M57,78 Q60,82 63,78"
+              stroke="#d4b8a8" stroke-width="1.2"
+              fill="none" stroke-linecap="round"/>
+
+        <!-- ── MOUTH VARIANTS ─────────────────────────────────── -->
+        <!-- idle: gentle neutral -->
+        <path class="lc-mouth lc-mouth-idle"
+              d="M53,88 Q60,92 67,88"
+              stroke="#c89080" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+        <!-- happy: wide arc smile -->
+        <path class="lc-mouth lc-mouth-happy"
+              d="M49,87 Q60,96 71,87"
+              stroke="#c89080" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+        <!-- surprised: small 'O' -->
+        <ellipse class="lc-mouth lc-mouth-surprised"
+                 cx="60" cy="91" rx="4.5" ry="4"
+                 fill="#904848" stroke="#703030" stroke-width="0.8"/>
+        <!-- thinking: slight asymmetric -->
+        <path class="lc-mouth lc-mouth-thinking"
+              d="M52,90 Q58,89 67,87"
+              stroke="#c89080" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+        <!-- talking open: wider O -->
+        <ellipse class="lc-mouth lc-mouth-talking-open"
+                 cx="60" cy="90" rx="5.5" ry="5"
+                 fill="#904848" stroke="#703030" stroke-width="0.8"/>
+        <!-- talking closed: thin line -->
+        <path class="lc-mouth lc-mouth-talking-closed"
+              d="M54,89 Q60,91 66,89"
+              stroke="#c89080" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+
+        <!-- Hood rim overlapping chin (bottom of hood, in front of face edge) -->
+        <path d="M33,92 Q33,115 60,117 Q87,115 87,92"
+              fill="url(#lc-hood)" opacity="0.7"/>
+
+      </g><!-- end .lain-head -->
+
+    </g><!-- end .lain-breathe -->
+  </g><!-- end .lain-float -->
+
+</svg>`;
+    }
+}
+
+window.LainCharacter = LainCharacter;

--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -26,6 +26,10 @@ class OrbitalNav {
         this.dustGroup   = null;
         this.navMeshes   = [];
 
+        // Optional hover callback: fired when hovered nav changes
+        this.onHoverChange  = null;   // (navId: string | null) => void
+        this._prevHoveredId = null;
+
         // Nav items — 7 screens on the primary orbital ring
         this.navDefs = [
             { id: 'diary',  label: 'DIARY',  color: 0xff8c00, baseAngle: 0 },
@@ -436,6 +440,12 @@ class OrbitalNav {
                 this.canvas.style.cursor = 'pointer';
             } else {
                 this.canvas.style.cursor = 'crosshair';
+            }
+
+            // Fire hover change callback when hovered nav changes
+            if (this.hoveredId !== this._prevHoveredId) {
+                this._prevHoveredId = this.hoveredId;
+                if (this.onHoverChange) this.onHoverChange(this.hoveredId);
             }
 
             this.renderer.render(this.scene, this.camera);


### PR DESCRIPTION
## Summary

- **New `LainCharacter` class** (`frontend/js/character.js`) renders a full anime-style Lain in her iconic bear pajamas as the hub focal point, replacing the 90×150px dark silhouette
- **SVG character anatomy**: bear ears with pink inner, hood with gradient, warm skin face, large anime eyes (iris / pupil / catchlights / eyelids), eyebrows (3 states), nose, 5 mouth variants, onesie body, paw hands, feet, chest paw-print
- **Animation system**:
  - `lain-float` — 5.5s gentle bob (whole character)
  - `lain-breathe` — 4s subtle chest rise/fall
  - `lain-idle-sway` — 8s very gentle rotation on hub container
  - `lc-aura-pulse` — 3.5s cyan glow pulse
  - **Blink** — CSS `scaleY(0→1)` eyelids, JS schedules random 3–7s intervals
- **6 emotional states**: `idle | happy | thinking | surprised | curious | talking` — each changes eyebrows, mouth shape, head tilt, blush intensity
- **Nav hover reactions**: character tilts head to `curious` when hovering orbital spheres, returns to `idle` on leave (via new `OrbitalNav.onHoverChange` callback)
- **Navigation reaction**: brief `surprised` pose on screen transition
- **Random idle poses**: thinking or happy every 15–30s, auto-reset after 3–5s
- **PSX aesthetic**: muted #cccce0/#9898b8 palette, deep navy iris, warm skin tones, SVG CRT color filter
- **`prefers-reduced-motion`**: all CSS animations disabled

## Test plan

- [ ] Lain character is visible and large at center of hub screen (~22vw wide)
- [ ] Character floats, breathes, sways continuously
- [ ] Blinks every few seconds (eyelids sweep down then open)
- [ ] Hovering a nav sphere causes head tilt (curious state)
- [ ] Navigating to a screen causes surprised expression
- [ ] Happy / thinking poses appear randomly during idle
- [ ] L A I N nameplate renders below character
- [ ] No console errors; no layout shifts; hub still navigates correctly
- [ ] Under prefers-reduced-motion all animations are disabled

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)