### PR TITLE
feat: PSX nav with ported GLSL shaders

### DIFF
--- a/frontend/js/nav.js
+++ b/frontend/js/nav.js
@@ -1,11 +1,145 @@
-/* ── OrbitalNav — PSX Game Scene ──────────────────────────────────────────────
+/* ── OrbitalNav — PSX Scene with ported GLSL shaders ──────────────────────────
    Faithful recreation of the lainTSX site scene:
-   - Middle ring (CylinderGeometry, semi-transparent, spinning)
-   - Lain LAPK sprite at center (handled by character.js)
-   - 7 navigation nodes on the ring
-   - Star field background
-   - Camera at FOV 55, positioned to match PSX framing
+   · Middle ring: CylinderGeometry + ShaderMaterial (simplex noise wobble)
+   · Star field:  background PlaneGeometry + gradient ShaderMaterial
+   · 7 nav orbs on the ring circumference
+   · Camera FOV 55, near 0.0001, far 2000
+   · Arrow keys (L/R = cycle, U/D = cycle) + Enter to activate
+   · window.OrbitalNav { init, start, stop, resume }
    ─────────────────────────────────────────────────────────────────────────── */
+
+// ── GLSL: middle ring vertex — simplex noise wobble (lainTSX port) ──────────
+
+const MIDDLE_RING_VERT = /* glsl */`
+varying vec2 vUv;
+varying vec3 vPosition;
+
+uniform float wobble_amplifier;
+uniform float noise_amplifier;
+
+vec3 mod289v3(vec3 x) { return x - floor(x * (1.0/289.0)) * 289.0; }
+vec4 mod289v4(vec4 x) { return x - floor(x * (1.0/289.0)) * 289.0; }
+vec4 permute(vec4 x)  { return mod289v4(((x*34.0)+1.0)*x); }
+vec4 taylorInvSqrt(vec4 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+
+float snoise(vec3 v) {
+  const vec2 C = vec2(1.0/6.0, 1.0/3.0);
+  const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  vec3 i  = floor(v + dot(v, C.yyy));
+  vec3 x0 = v - i + dot(i, C.xxx);
+
+  vec3 g  = step(x0.yzx, x0.xyz);
+  vec3 l  = 1.0 - g;
+  vec3 i1 = min(g.xyz, l.zxy);
+  vec3 i2 = max(g.xyz, l.zxy);
+
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+
+  i = mod289v3(i);
+  vec4 p = permute(permute(permute(
+               i.z + vec4(0.0, i1.z, i2.z, 1.0))
+             + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+             + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+  float n_ = 0.142857142857;
+  vec3  ns  = n_ * D.wyz - D.xzx;
+  vec4  j   = p - 49.0 * floor(p * ns.z * ns.z);
+
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_);
+  vec4 x  = x_ * ns.x + ns.yyyy;
+  vec4 y  = y_ * ns.x + ns.yyyy;
+  vec4 h  = 1.0 - abs(x) - abs(y);
+
+  vec4 b0 = vec4(x.xy, y.xy);
+  vec4 b1 = vec4(x.zw, y.zw);
+  vec4 s0 = floor(b0)*2.0 + 1.0;
+  vec4 s1 = floor(b1)*2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+
+  vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2,p2), dot(p3,p3)));
+  p0 *= norm.x; p1 *= norm.y; p2 *= norm.z; p3 *= norm.w;
+
+  vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+  m = m * m;
+  return 42.0 * dot(m*m, vec4(dot(p0,x0), dot(p1,x1), dot(p2,x2), dot(p3,x3)));
+}
+
+void main() {
+  vPosition = position;
+  vUv = uv;
+
+  const float angleOffset = -0.8;
+  // w=0 → direction vector, translation-independent world XZ angle
+  vec4 worldPos = modelMatrix * vec4(position, 0.0);
+  float wobbleAngle = atan(worldPos.x, worldPos.z) + angleOffset;
+
+  vec3 pos = position;
+  float noiseFreq = 0.5;
+  vec3 noisePos = vec3(pos.x * noiseFreq, pos.y, pos.z);
+  pos.y += snoise(noisePos) * noise_amplifier + wobble_amplifier * sin(wobbleAngle * 2.0);
+
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+}
+`;
+
+// ── GLSL: middle ring fragment — 32-slice gaps, procedural purple ────────────
+
+const MIDDLE_RING_FRAG = /* glsl */`
+uniform float gap_size;
+varying vec2 vUv;
+varying vec3 vPosition;
+
+void main() {
+    float slice_count      = 32.0;
+    float slice_position   = vUv.x * slice_count;
+    float pos_in_slice     = fract(slice_position);
+
+    if (pos_in_slice < gap_size * 0.5 || pos_in_slice > (1.0 - gap_size * 0.5)) {
+        discard;
+    }
+
+    vec3 ringColor = mix(vec3(0.35, 0.30, 0.70), vec3(0.60, 0.50, 0.95), vUv.y);
+    gl_FragColor = vec4(ringColor, 0.5);
+}
+`;
+
+// ── GLSL: star background vertex (lainTSX port) ──────────────────────────────
+
+const STAR_VERT = /* glsl */`
+varying vec2 vUv;
+void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+// ── GLSL: star background fragment — y-gradient (lainTSX port) ──────────────
+
+const STAR_FRAG = /* glsl */`
+uniform vec3 color1;
+uniform vec3 color2;
+
+varying vec2 vUv;
+
+void main() {
+    float alpha    = smoothstep(0.0, 1.0, vUv.y);
+    float colorMix = smoothstep(1.0, 2.0, 1.8);
+    gl_FragColor   = vec4(mix(color1, color2, colorMix), alpha) * 0.8;
+}
+`;
+
+// ── Nav item definitions ─────────────────────────────────────────────────────
 
 const NAV_ITEMS = [
     { id: 'diary',  label: 'DIARY',  code: 'Lda', color: 0xff8c00 },
@@ -17,179 +151,228 @@ const NAV_ITEMS = [
     { id: 'wired',  label: 'WIRED',  code: 'Wrd', color: 0x4488ff },
 ];
 
+// PSX scene constants (from lainTSX/src/site.ts)
+const RING_Y       = -0.14;
+const RING_Z       = -2.6;
+const RING_RADIUS  =  2.2;
+
 class OrbitalNav {
     constructor(canvas, labelsContainer, onNavigate) {
-        this.canvas     = canvas;
-        this.labelsEl   = labelsContainer;
-        this.onNavigate = onNavigate;
-        this.running    = false;
-        this.hoveredId  = null;
+        this.canvas        = canvas;
+        this.labelsEl      = labelsContainer;
+        this.onNavigate    = onNavigate || (() => {});
+        this.running       = false;
         this.selectedIndex = 0;
+        this.onHoverChange = null;
 
-        this.scene    = null;
-        this.camera   = null;
-        this.renderer = null;
-        this.clock    = null;
+        this.scene        = null;
+        this.camera       = null;
+        this.renderer     = null;
+        this.clock        = null;
 
         this.middleRing   = null;
+        this.ringUniforms = null;
+        this._outerRing   = null;
+        this._crossRing   = null;
         this.navMeshes    = [];
-        this.navLabels    = [];
-        this.starField    = null;
-
-        this.onHoverChange = null;
+        this.navGlows     = [];
+        this.starBg       = null;
+        this.starPoints   = null;
+        this._rafId       = null;
 
         this._boundResize  = () => this._onResize();
         this._boundKeyDown = (e) => this._onKeyDown(e);
     }
 
-    init() { this.start(); }
+    // Public API — init/resume are aliases so callers can use either convention
+    init()   { this.start(); }
     resume() { if (!this.running) this.start(); }
 
     start() {
         if (this.running) return;
         this.running = true;
 
-        // Scene
+        // ── Scene ────────────────────────────────────────────────────────────
         this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(0x0a0a1a);
 
-        // Camera — PSX FOV 55
-        const w = this.canvas.clientWidth || window.innerWidth;
+        // ── Camera — PSX FOV 55 ──────────────────────────────────────────────
+        const w = this.canvas.clientWidth  || window.innerWidth;
         const h = this.canvas.clientHeight || window.innerHeight;
-        this.camera = new THREE.PerspectiveCamera(55, w / h, 0.01, 2000);
+        this.camera = new THREE.PerspectiveCamera(55, w / h, 0.0001, 2000);
         this.camera.position.set(0, 0.3, 4.5);
         this.camera.lookAt(0, -0.1, 0);
 
-        // Renderer
-        this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true, alpha: true });
+        // ── Renderer ─────────────────────────────────────────────────────────
+        this.renderer = new THREE.WebGLRenderer({
+            canvas:    this.canvas,
+            antialias: true,
+            alpha:     true,
+        });
         this.renderer.setPixelRatio(window.devicePixelRatio);
         this.renderer.setSize(w, h);
+        this.renderer.toneMapping      = THREE.NoToneMapping;
+        this.renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
 
         this.clock = new THREE.Clock();
 
-        // Build scene
-        this._createStarField();
+        // ── Build scene ──────────────────────────────────────────────────────
+        this._createStarBackground();
+        this._createStarPoints();
         this._createMiddleRing();
         this._createNavNodes();
-        this._createAmbientLight();
+        this._createLights();
         this._updateLabels();
 
-        // Events
-        window.addEventListener('resize', this._boundResize);
+        // ── Events ───────────────────────────────────────────────────────────
+        window.addEventListener('resize',  this._boundResize);
         window.addEventListener('keydown', this._boundKeyDown);
-        this.canvas.addEventListener('click', (e) => this._onClick(e));
 
         this._animate();
     }
 
     stop() {
         this.running = false;
-        window.removeEventListener('resize', this._boundResize);
+        if (this._rafId) { cancelAnimationFrame(this._rafId); this._rafId = null; }
+        window.removeEventListener('resize',  this._boundResize);
         window.removeEventListener('keydown', this._boundKeyDown);
-        if (this.renderer) this.renderer.dispose();
+        if (this.renderer) { this.renderer.dispose(); this.renderer = null; }
     }
 
-    // ── Star Field ──
-    _createStarField() {
+    // ── Star background (star.vert + star.frag) ──────────────────────────────
+    _createStarBackground() {
+        const geo = new THREE.PlaneGeometry(160, 160);
+        const mat = new THREE.ShaderMaterial({
+            vertexShader:   STAR_VERT,
+            fragmentShader: STAR_FRAG,
+            uniforms: {
+                color1: { value: new THREE.Color(0x000510) },
+                color2: { value: new THREE.Color(0x020118) },
+            },
+            transparent: true,
+            depthWrite:  false,
+        });
+        this.starBg = new THREE.Mesh(geo, mat);
+        this.starBg.position.z = -80;
+        this.scene.add(this.starBg);
+    }
+
+    // ── Star points field ────────────────────────────────────────────────────
+    _createStarPoints() {
         const count = 1500;
-        const positions = new Float32Array(count * 3);
+        const pos   = new Float32Array(count * 3);
         for (let i = 0; i < count; i++) {
-            positions[i * 3]     = (Math.random() - 0.5) * 200;
-            positions[i * 3 + 1] = (Math.random() - 0.5) * 200;
-            positions[i * 3 + 2] = (Math.random() - 0.5) * 200;
+            pos[i * 3]     = (Math.random() - 0.5) * 200;
+            pos[i * 3 + 1] = (Math.random() - 0.5) * 200;
+            pos[i * 3 + 2] = (Math.random() - 0.5) * 200;
         }
         const geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
         const mat = new THREE.PointsMaterial({
-            color: 0xffffff,
-            size: 0.15,
-            transparent: true,
-            opacity: 0.6,
+            color:           0xffffff,
+            size:            0.15,
+            transparent:     true,
+            opacity:         0.7,
             sizeAttenuation: true,
+            depthWrite:      false,
         });
-
-        this.starField = new THREE.Points(geo, mat);
-        this.scene.add(this.starField);
+        this.starPoints = new THREE.Points(geo, mat);
+        this.scene.add(this.starPoints);
     }
 
-    // ── Middle Ring (PSX CylinderGeometry) ──
+    // ── Middle ring — ShaderMaterial with simplex noise wobble ───────────────
     _createMiddleRing() {
-        const geo = new THREE.CylinderGeometry(2.2, 2.2, 0.06, 64, 1, true);
-
-        const mat = new THREE.MeshBasicMaterial({
-            color: 0x8b7cc8,
-            wireframe: false,
-            transparent: true,
-            opacity: 0.35,
-            side: THREE.DoubleSide,
+        // Primary ring (MIDDLE_RING_POS_Y=-0.14, MIDDLE_RING_POS_Z=-2.6)
+        this.ringUniforms = {
+            wobble_amplifier: { value: 0.0 },
+            noise_amplifier:  { value: 0.0 },
+            gap_size:         { value: 0.10 },
+        };
+        const mat = new THREE.ShaderMaterial({
+            vertexShader:   MIDDLE_RING_VERT,
+            fragmentShader: MIDDLE_RING_FRAG,
+            uniforms:       this.ringUniforms,
+            transparent:    true,
+            side:           THREE.DoubleSide,
+            depthWrite:     false,
         });
-
-        this.middleRing = new THREE.Mesh(geo, mat);
-        this.middleRing.position.y = -0.2;
+        this.middleRing = new THREE.Mesh(
+            new THREE.CylinderGeometry(RING_RADIUS, RING_RADIUS, 0.06, 64, 1, true),
+            mat
+        );
+        this.middleRing.position.set(0, RING_Y, RING_Z);
         this.scene.add(this.middleRing);
 
-        // Second ring (outer, gray, thinner)
-        const geo2 = new THREE.CylinderGeometry(3.2, 3.2, 0.03, 64, 1, true);
-        const mat2 = new THREE.MeshBasicMaterial({
-            color: 0x555570,
-            transparent: true,
-            opacity: 0.2,
-            side: THREE.DoubleSide,
-        });
-        const outerRing = new THREE.Mesh(geo2, mat2);
-        outerRing.position.y = -0.2;
-        this.scene.add(outerRing);
+        // Outer gray ring
+        this._outerRing = new THREE.Mesh(
+            new THREE.CylinderGeometry(3.2, 3.2, 0.03, 64, 1, true),
+            new THREE.ShaderMaterial({
+                vertexShader:   MIDDLE_RING_VERT,
+                fragmentShader: MIDDLE_RING_FRAG,
+                uniforms: {
+                    wobble_amplifier: { value: 0.0 },
+                    noise_amplifier:  { value: 0.0 },
+                    gap_size:         { value: 0.15 },
+                },
+                transparent: true,
+                side:        THREE.DoubleSide,
+                depthWrite:  false,
+            })
+        );
+        this._outerRing.position.set(0, RING_Y, RING_Z);
+        this.scene.add(this._outerRing);
 
-        // Third ring (tilted, crossing)
-        const geo3 = new THREE.CylinderGeometry(2.5, 2.5, 0.04, 64, 1, true);
-        const mat3 = new THREE.MeshBasicMaterial({
-            color: 0x6a5aa0,
-            transparent: true,
-            opacity: 0.2,
-            side: THREE.DoubleSide,
-        });
-        const crossRing = new THREE.Mesh(geo3, mat3);
-        crossRing.position.y = -0.2;
-        crossRing.rotation.x = Math.PI / 3;
-        crossRing.rotation.z = Math.PI / 6;
-        this.scene.add(crossRing);
-        this._crossRing = crossRing;
+        // Tilted crossing ring
+        this._crossRing = new THREE.Mesh(
+            new THREE.CylinderGeometry(2.5, 2.5, 0.04, 64, 1, true),
+            new THREE.ShaderMaterial({
+                vertexShader:   MIDDLE_RING_VERT,
+                fragmentShader: MIDDLE_RING_FRAG,
+                uniforms: {
+                    wobble_amplifier: { value: 0.0 },
+                    noise_amplifier:  { value: 0.0 },
+                    gap_size:         { value: 0.12 },
+                },
+                transparent: true,
+                side:        THREE.DoubleSide,
+                depthWrite:  false,
+            })
+        );
+        this._crossRing.position.set(0, RING_Y, RING_Z);
+        this._crossRing.rotation.x = Math.PI / 3;
+        this._crossRing.rotation.z = Math.PI / 6;
+        this.scene.add(this._crossRing);
     }
 
-    // ── Navigation Nodes ──
+    // ── 7 nav orbs placed on ring circumference ──────────────────────────────
     _createNavNodes() {
         this.navMeshes = [];
+        this.navGlows  = [];
 
         NAV_ITEMS.forEach((item, i) => {
             const angle = (i / NAV_ITEMS.length) * Math.PI * 2;
-            const radius = 2.2;
-            const x = Math.sin(angle) * radius;
-            const z = Math.cos(angle) * radius;
+            const x = Math.sin(angle) * RING_RADIUS;
+            const z = RING_Z + Math.cos(angle) * RING_RADIUS;
 
-            // Node sphere
-            const geo = new THREE.SphereGeometry(0.15, 16, 16);
-            const mat = new THREE.MeshBasicMaterial({
-                color: item.color,
-                transparent: true,
-                opacity: 0.8,
-            });
-            const mesh = new THREE.Mesh(geo, mat);
-            mesh.position.set(x, -0.2, z);
+            const mesh = new THREE.Mesh(
+                new THREE.SphereGeometry(0.15, 16, 16),
+                new THREE.MeshBasicMaterial({
+                    color: item.color, transparent: true, opacity: 0.8,
+                })
+            );
+            mesh.position.set(x, RING_Y, z);
             mesh.userData = { navId: item.id, index: i };
             this.scene.add(mesh);
             this.navMeshes.push(mesh);
 
-            // Glow sphere
-            const glowGeo = new THREE.SphereGeometry(0.25, 16, 16);
-            const glowMat = new THREE.MeshBasicMaterial({
-                color: item.color,
-                transparent: true,
-                opacity: 0.12,
-            });
-            const glow = new THREE.Mesh(glowGeo, glowMat);
+            const glow = new THREE.Mesh(
+                new THREE.SphereGeometry(0.28, 16, 16),
+                new THREE.MeshBasicMaterial({
+                    color: item.color, transparent: true, opacity: 0.12, depthWrite: false,
+                })
+            );
             glow.position.copy(mesh.position);
             this.scene.add(glow);
+            this.navGlows.push(glow);
         });
 
         this._highlightSelected();
@@ -197,114 +380,121 @@ class OrbitalNav {
 
     _highlightSelected() {
         this.navMeshes.forEach((mesh, i) => {
-            const isSelected = i === this.selectedIndex;
-            mesh.material.opacity = isSelected ? 1.0 : 0.5;
-            mesh.scale.setScalar(isSelected ? 1.5 : 1.0);
+            const sel = i === this.selectedIndex;
+            mesh.material.opacity = sel ? 1.0 : 0.5;
+            mesh.scale.setScalar(sel ? 1.5 : 1.0);
         });
         this._updateLabels();
     }
 
-    // ── Ambient Light ──
-    _createAmbientLight() {
+    // ── Lights ───────────────────────────────────────────────────────────────
+    _createLights() {
         this.scene.add(new THREE.AmbientLight(0x404060, 0.5));
-        const point = new THREE.PointLight(0x00d4aa, 0.5, 10);
-        point.position.set(0, 2, 3);
-        this.scene.add(point);
+        const pt = new THREE.PointLight(0x00d4aa, 0.5, 10);
+        pt.position.set(0, 2, 3);
+        this.scene.add(pt);
     }
 
-    // ── Labels (HTML overlay) ──
+    // ── HTML label overlay ───────────────────────────────────────────────────
     _updateLabels() {
-        if (!this.labelsEl) return;
+        if (!this.labelsEl || !this.camera) return;
         this.labelsEl.innerHTML = '';
 
         NAV_ITEMS.forEach((item, i) => {
             const mesh = this.navMeshes[i];
             if (!mesh) return;
 
-            // Project to screen
-            const pos = mesh.position.clone();
-            pos.project(this.camera);
+            const ndc = mesh.position.clone().project(this.camera);
+            if (ndc.z > 1) return;                   // behind camera
 
-            const hw = this.canvas.clientWidth / 2;
+            const hw = this.canvas.clientWidth  / 2;
             const hh = this.canvas.clientHeight / 2;
-            const sx = (pos.x * hw) + hw;
-            const sy = -(pos.y * hh) + hh;
+            const sx =  ndc.x * hw + hw;
+            const sy = -ndc.y * hh + hh;
 
-            // Only show if in front of camera
-            if (pos.z > 1) return;
-
-            const isSelected = i === this.selectedIndex;
-            const label = document.createElement('div');
-            label.className = 'nav-label-item' + (isSelected ? ' selected' : '');
-            label.dataset.target = item.id;
-            label.innerHTML = `
-                <span class="nav-label-code" style="color:${isSelected ? '#ff8c00' : '#666'}">${item.code}0${i+1}0</span>
+            const sel = i === this.selectedIndex;
+            const div = document.createElement('div');
+            div.className    = 'nav-label-item' + (sel ? ' selected' : '');
+            div.dataset.target = item.id;
+            div.innerHTML    = `
+                <span class="nav-label-code" style="color:${sel ? '#ff8c00' : '#666'}">${item.code}0${i + 1}0</span>
                 <span class="nav-label-name">${item.label}</span>
             `;
-            label.style.position = 'absolute';
-            label.style.left = sx + 'px';
-            label.style.top = (sy - 30) + 'px';
-            label.style.transform = 'translate(-50%, -100%)';
-            label.style.opacity = isSelected ? '1' : '0.5';
-            label.style.pointerEvents = 'auto';
-            label.style.cursor = 'pointer';
-            label.addEventListener('click', () => {
+            div.style.cssText = `
+                position:absolute;
+                left:${sx}px;
+                top:${sy - 30}px;
+                transform:translate(-50%,-100%);
+                opacity:${sel ? 1 : 0.5};
+                pointer-events:auto;
+                cursor:pointer;
+            `;
+            div.addEventListener('click', () => {
                 this.selectedIndex = i;
                 this._highlightSelected();
                 this.onNavigate(item.id);
             });
-            this.labelsEl.appendChild(label);
+            this.labelsEl.appendChild(div);
         });
     }
 
-    // ── Input ──
+    // ── Keyboard input ───────────────────────────────────────────────────────
     _onKeyDown(e) {
-        if (e.key === 'ArrowLeft' || e.key === 'a') {
-            this.selectedIndex = (this.selectedIndex - 1 + NAV_ITEMS.length) % NAV_ITEMS.length;
-            this._highlightSelected();
-        } else if (e.key === 'ArrowRight' || e.key === 'd') {
-            this.selectedIndex = (this.selectedIndex + 1) % NAV_ITEMS.length;
-            this._highlightSelected();
-        } else if (e.key === 'Enter' || e.key === ' ') {
-            const item = NAV_ITEMS[this.selectedIndex];
-            if (item) this.onNavigate(item.id);
+        const n = NAV_ITEMS.length;
+        switch (e.key) {
+            case 'ArrowLeft':
+            case 'ArrowUp':
+                this.selectedIndex = (this.selectedIndex - 1 + n) % n;
+                this._highlightSelected();
+                break;
+            case 'ArrowRight':
+            case 'ArrowDown':
+                this.selectedIndex = (this.selectedIndex + 1) % n;
+                this._highlightSelected();
+                break;
+            case 'Enter': {
+                const item = NAV_ITEMS[this.selectedIndex];
+                if (item) this.onNavigate(item.id);
+                break;
+            }
         }
     }
 
-    _onClick(e) {
-        // Simple click on labels handles navigation
-    }
-
-    // ── Render Loop ──
+    // ── Render loop ──────────────────────────────────────────────────────────
     _animate() {
         if (!this.running) return;
-        requestAnimationFrame(() => this._animate());
+        this._rafId = requestAnimationFrame(() => this._animate());
 
         const t = this.clock.getElapsedTime();
 
-        // Spin middle ring (like PSX)
-        if (this.middleRing) {
-            this.middleRing.rotation.y = t * 0.3;
+        // Animate wobble uniforms — gentle idle oscillation
+        if (this.ringUniforms) {
+            this.ringUniforms.wobble_amplifier.value = 0.05 * Math.sin(t * 0.7);
+            this.ringUniforms.noise_amplifier.value  = 0.03 * Math.abs(Math.sin(t * 0.3));
         }
 
-        // Cross ring counter-spin
-        if (this._crossRing) {
-            this._crossRing.rotation.y = -t * 0.15;
-        }
+        // Spin rings (primary CW, outer + cross CCW)
+        if (this.middleRing) this.middleRing.rotation.y =  t * 0.3;
+        if (this._outerRing) this._outerRing.rotation.y = -t * 0.15;
+        if (this._crossRing) this._crossRing.rotation.y = -t * 0.15;
 
-        // Subtle star field rotation
-        if (this.starField) {
-            this.starField.rotation.y = t * 0.01;
-        }
+        // Slow star drift
+        if (this.starPoints) this.starPoints.rotation.y  = t * 0.01;
+        if (this.starBg)     this.starBg.rotation.z      = t * 0.002;
 
-        // Update label positions
+        // Orb Y-bob
+        this.navMeshes.forEach((mesh, i) => {
+            const y = RING_Y + Math.sin(t * 1.2 + i * 0.9) * 0.04;
+            mesh.position.y = y;
+            if (this.navGlows[i]) this.navGlows[i].position.y = y;
+        });
+
         this._updateLabels();
-
         this.renderer.render(this.scene, this.camera);
     }
 
     _onResize() {
-        const w = this.canvas.clientWidth || window.innerWidth;
+        const w = this.canvas.clientWidth  || window.innerWidth;
         const h = this.canvas.clientHeight || window.innerHeight;
         this.camera.aspect = w / h;
         this.camera.updateProjectionMatrix();


### PR DESCRIPTION
## Summary

- **Middle ring**: `CylinderGeometry` + `ShaderMaterial` using ported simplex noise wobble vertex shader (`middle_ring.vert`) and 32-slice gap fragment shader (`middle_ring.frag`) — procedural purple, no texture atlas dependency
- **Star field**: background `PlaneGeometry` with ported gradient `ShaderMaterial` (`star.vert` / `star.frag`) + 1500-point star cloud
- **7 nav orbs** placed on ring circumference at PSX-faithful coordinates (`y=-0.14`, `z=-2.6`, `r=2.2`)
- **Camera** FOV 55, near `0.0001`, far `2000` — matches `lainTSX/src/engine.ts` constants
- Arrow keys (L/R/U/D cycle) + Enter to activate; HTML label overlay with code + name
- `window.OrbitalNav` exports `init`, `start`, `stop`, `resume`

## Test plan

- [ ] Canvas renders without WebGL errors; middle ring visible with shimmer/wobble
- [ ] Arrow keys cycle through 7 nav items; selected orb scales up and label turns orange
- [ ] Enter key fires `onNavigate(id)` callback
- [ ] Window resize updates camera aspect + renderer size
- [ ] `stop()` cancels RAF and disposes renderer; `resume()` restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)