### PR TITLE
fix: unify Three.js to single r169 instance via module shim (issue #92)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -278,22 +278,22 @@
     </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
-<script src="js/data-rain.js"></script>
-<script src="js/audio.js"></script>
-<script src="js/effects.js"></script>
-<script src="js/chat.js"></script>
-<script src="js/nav.js"></script>
-<script src="js/psyche.js"></script>
-<script src="js/memory.js"></script>
-<script src="js/status.js"></script>
-<script src="js/tasks.js"></script>
-<script src="js/search.js"></script>
-<script src="js/wired.js"></script>
-<script src="js/hotkeys.js"></script>
-<script src="js/character.js"></script>
+<script type="module" src="js/three-global.js"></script>
+<script defer src="js/data-rain.js"></script>
+<script defer src="js/audio.js"></script>
+<script defer src="js/effects.js"></script>
+<script defer src="js/chat.js"></script>
+<script defer src="js/nav.js"></script>
+<script defer src="js/psyche.js"></script>
+<script defer src="js/memory.js"></script>
+<script defer src="js/status.js"></script>
+<script defer src="js/tasks.js"></script>
+<script defer src="js/search.js"></script>
+<script defer src="js/wired.js"></script>
+<script defer src="js/hotkeys.js"></script>
+<script defer src="js/character.js"></script>
 <script type="module" src="js/character-vrm.js"></script>
 <script type="module" src="js/effects-vrm.js"></script>
-<script src="js/app.js"></script>
+<script defer src="js/app.js"></script>
 </body>
 </html>

--- a/frontend/js/three-global.js
+++ b/frontend/js/three-global.js
@@ -1,0 +1,3 @@
+// three-global.js — expose importmap Three.js r169 as window.THREE for classic scripts
+import * as THREE from "three";
+window.THREE = THREE;


### PR DESCRIPTION
## Problem

Post-deploy QA on PR #91 found `Multiple instances of Three.js being imported` console warning.

- `index.html` loaded `three@0.160.0` as a UMD classic script (for orbital nav / effects)
- The importmap pulled `three@0.169.0` ES module (for VRM modules)
- Two separate instances → different prototypes → instanceof breaks, textures incompatible

## Fix

**Two changes, zero JS rewrites:**

1. **`frontend/js/three-global.js`** (new, 3 lines) — ES module shim that imports Three.js r169 from the importmap and assigns to `window.THREE`, making it available to all classic scripts
2. **`frontend/index.html`** — replace the `<script src=three@0.160.0>` tag with `<script type="module" src="js/three-global.js">`; add `defer` to all following classic scripts so they execute after the module shim sets `window.THREE`

No existing JS files modified. No classic scripts converted to ES modules.

## Result
- Single Three.js r169 instance for the entire page
- No `Multiple instances` warning
- Orbital nav / effects / VRM all share the same prototype chain
- Fixes: #92