### PR TITLE
feat: Phase 3 — SEL Atmosphere Effects (background + particles + effects polish)

### DIFF
--- a/frontend/js/atmosphere-vrm.js
+++ b/frontend/js/atmosphere-vrm.js
@@ -1,0 +1,151 @@
+/* ── SEL Atmosphere — background + ambient particles ──────────────────────────
+   Phase 3 of VRM 3D Lain. Exports:
+     initAtmosphere(scene)          — add background plane + particle system
+     updateAtmosphere(delta, t)     — tick particles each frame
+   ─────────────────────────────────────────────────────────────────────────── */
+
+import * as THREE from 'three';
+
+const PARTICLE_COUNT = 800;
+
+let _particles    = null;   // Points object
+let _positions    = null;   // Float32Array  (xyz per particle)
+let _velocities   = null;   // Float32Array  (vy per particle — upward drift)
+let _bounds       = null;   // {xMin,xMax,yMin,yMax,zMin,zMax}
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Add dark background plane and floating particle system to the VRM scene.
+ * Call once after the scene + camera are set up.
+ *
+ * @param {THREE.Scene}  scene
+ * @param {Object}       [opts]
+ * @param {number}       [opts.particleCount=800]
+ * @param {number}       [opts.bgZ=-0.8]   — Z position of background plane
+ */
+export function initAtmosphere(scene, opts = {}) {
+    const {
+        particleCount = PARTICLE_COUNT,
+        bgZ           = -0.8,
+    } = opts;
+
+    _addBackground(scene, bgZ);
+    _addParticles(scene, particleCount);
+}
+
+/**
+ * Animate particles. Call each RAF tick.
+ * @param {number} delta — seconds since last frame
+ * @param {number} t     — total elapsed seconds
+ */
+export function updateAtmosphere(delta, t) {
+    if (!_particles || !_positions) return;
+
+    const geo  = _particles.geometry;
+    const attr = geo.attributes.position;
+    const n    = _velocities.length;
+
+    for (let i = 0; i < n; i++) {
+        const base = i * 3;
+
+        // Upward drift + gentle horizontal sway (sine)
+        _positions[base + 1] += _velocities[i] * delta;
+        _positions[base]     += Math.sin(t * 0.3 + i * 0.7) * 0.0002;
+
+        // Wrap: when particle exits top, respawn at bottom
+        if (_positions[base + 1] > _bounds.yMax) {
+            _positions[base + 1] = _bounds.yMin;
+            _positions[base]     = _bounds.xMin + Math.random() * (_bounds.xMax - _bounds.xMin);
+            _positions[base + 2] = _bounds.zMin + Math.random() * (_bounds.zMax - _bounds.zMin);
+        }
+    }
+
+    attr.array.set(_positions);
+    attr.needsUpdate = true;
+
+    // Gentle opacity pulse
+    _particles.material.opacity = 0.45 + Math.sin(t * 0.4) * 0.07;
+}
+
+// ── Internals ────────────────────────────────────────────────
+
+function _addBackground(scene, bgZ) {
+    // Gradient via vertex colours: deep navy at bottom, dark purple at top
+    const W = 4, H = 6;
+    const geo = new THREE.PlaneGeometry(W, H, 1, 1);
+
+    // Bottom two verts = navy (#0a0a1a), top two = purple (#16082e)
+    const colBottom = new THREE.Color(0x0a0a1a);
+    const colTop    = new THREE.Color(0x16082e);
+
+    const colors = new Float32Array(4 * 3); // 4 verts × rgb
+    // PlaneGeometry verts: [BL, BR, TL, TR]
+    const vColors = [colBottom, colBottom, colTop, colTop];
+    vColors.forEach((c, i) => {
+        colors[i * 3]     = c.r;
+        colors[i * 3 + 1] = c.g;
+        colors[i * 3 + 2] = c.b;
+    });
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+    const mat = new THREE.MeshBasicMaterial({
+        vertexColors: true,
+        side:         THREE.FrontSide,
+        depthWrite:   false,
+    });
+
+    const bg = new THREE.Mesh(geo, mat);
+    bg.position.set(0, 1.3, bgZ);   // centred on character's bust-up framing
+    bg.renderOrder = -1;             // always behind everything
+    scene.add(bg);
+}
+
+function _addParticles(scene, count) {
+    // Spawn particles in a volume in front of the background, around the character
+    _bounds = { xMin: -0.8, xMax: 0.8, yMin: 0.3, yMax: 2.5, zMin: -0.6, zMax: 0.5 };
+
+    _positions  = new Float32Array(count * 3);
+    _velocities = new Float32Array(count);
+
+    for (let i = 0; i < count; i++) {
+        const b = i * 3;
+        _positions[b]     = _bounds.xMin + Math.random() * (_bounds.xMax - _bounds.xMin);
+        _positions[b + 1] = _bounds.yMin + Math.random() * (_bounds.yMax - _bounds.yMin);
+        _positions[b + 2] = _bounds.zMin + Math.random() * (_bounds.zMax - _bounds.zMin);
+        _velocities[i]    = 0.025 + Math.random() * 0.055;  // 0.025–0.08 units/s upward
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(_positions, 3));
+
+    // Each particle picks a random SEL palette hue: cyan / cornflower / lavender
+    const palette = [
+        new THREE.Color(0x00e5ff),   // cyan
+        new THREE.Color(0x6495ed),   // cornflower blue
+        new THREE.Color(0xb0a8f0),   // lavender
+        new THREE.Color(0x8888ff),   // periwinkle
+    ];
+    const colArr = new Float32Array(count * 3);
+    for (let i = 0; i < count; i++) {
+        const c = palette[Math.floor(Math.random() * palette.length)];
+        colArr[i * 3]     = c.r;
+        colArr[i * 3 + 1] = c.g;
+        colArr[i * 3 + 2] = c.b;
+    }
+    geo.setAttribute('color', new THREE.BufferAttribute(colArr, 3));
+
+    const mat = new THREE.PointsMaterial({
+        size:         0.012,
+        vertexColors: true,
+        blending:     THREE.AdditiveBlending,
+        transparent:  true,
+        opacity:      0.45,
+        depthWrite:   false,
+        sizeAttenuation: true,
+    });
+
+    _particles = new THREE.Points(geo, mat);
+    _particles.renderOrder = 1;  // in front of background, behind VRM (VRM renders at 0)
+    scene.add(_particles);
+}

--- a/frontend/js/character-vrm.js
+++ b/frontend/js/character-vrm.js
@@ -8,7 +8,8 @@
 import * as THREE from 'three';
 import { GLTFLoader }                                 from 'three/addons/loaders/GLTFLoader.js';
 import { VRMLoaderPlugin, VRMUtils, VRMExpressionPresetName } from '@pixiv/three-vrm';
-import { initEffects, triggerGlitch, renderFrame }    from './effects-vrm.js';
+import { initEffects, triggerGlitch, renderFrame, onEffectsResize } from './effects-vrm.js';
+import { initAtmosphere, updateAtmosphere }           from './atmosphere-vrm.js';
 
 const VRM_PATH  = 'models/lain.vrm';
 const CAM_FOV   = 28;    // tight portrait framing
@@ -202,10 +203,13 @@ class LainVrmCharacter {
         rim.position.set(-1.0, 0.5, -1.0);
         this._scene.add(rim);
 
-        // ── FIX #1 (MAJOR): initialise EffectComposer here ──
+        // Initialise EffectComposer (bloom + film grain + glitch)
         initEffects(this._renderer, this._scene, this._camera);
 
-        // ── FIX #3 (MINOR): ResizeObserver — keep canvas in sync with container ──
+        // Initialise atmosphere: dark background plane + ambient particles
+        initAtmosphere(this._scene);
+
+        // ResizeObserver — keep canvas, composer, and camera in sync with container
         if (this._el && window.ResizeObserver) {
             this._resizeObs = new ResizeObserver(entries => {
                 for (const entry of entries) {
@@ -214,6 +218,7 @@ class LainVrmCharacter {
                         this._renderer.setSize(width, height, false);
                         this._camera.aspect = width / height;
                         this._camera.updateProjectionMatrix();
+                        onEffectsResize(width, height);
                     }
                 }
             });
@@ -297,6 +302,9 @@ class LainVrmCharacter {
 
         // Per-state procedural bone animations with smooth state blending
         this._animateProcedural(t);
+
+        // Atmosphere: tick ambient particles
+        updateAtmosphere(delta, t);
 
         this._vrm.update(delta);
     }

--- a/frontend/js/effects-vrm.js
+++ b/frontend/js/effects-vrm.js
@@ -1,19 +1,21 @@
 /* ── VRM Post-processing Effects ─────────────────────────────────────────────
-   SEL atmosphere: bloom glow, film grain, glitch on state transitions.
+   SEL atmosphere: bloom glow, film grain/scanlines, glitch on state transitions.
    Uses EffectComposer from Three.js r169 addons.
-   Exports: initEffects(renderer, scene, camera), triggerGlitch(), renderFrame()
+   Exports: initEffects(renderer, scene, camera), triggerGlitch(), renderFrame(),
+            onEffectsResize(width, height)
    Also exposes window.vrmEffects for classic-script consumers.
    ─────────────────────────────────────────────────────────────────────────── */
 
 import * as THREE from 'three';
-import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-import { RenderPass }     from 'three/addons/postprocessing/RenderPass.js';
-import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-import { FilmPass }       from 'three/addons/postprocessing/FilmPass.js';
-import { GlitchPass }     from 'three/addons/postprocessing/GlitchPass.js';
-import { OutputPass }     from 'three/addons/postprocessing/OutputPass.js';
+import { EffectComposer }   from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass }       from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass }  from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { FilmPass }         from 'three/addons/postprocessing/FilmPass.js';
+import { GlitchPass }       from 'three/addons/postprocessing/GlitchPass.js';
+import { OutputPass }       from 'three/addons/postprocessing/OutputPass.js';
 
 let _composer   = null;
+let _bloom      = null;
 let _glitchPass = null;
 let _glitchTmr  = null;
 
@@ -32,20 +34,26 @@ export function initEffects(renderer, scene, camera) {
     // Base scene render
     _composer.addPass(new RenderPass(scene, camera));
 
-    // Unreal bloom — subtle glow on bright highlights
-    const bloom = new UnrealBloomPass(size, 0.4, 0.5, 0.85);
-    _composer.addPass(bloom);
+    // Unreal bloom — soft SEL glow on highlights
+    // strength 0.55: noticeable but not blown-out
+    // radius   0.6:  wider glow spread for dreamy look
+    // threshold 0.75: only bloom near-white highlights (Lain's hair, rim light)
+    _bloom = new UnrealBloomPass(size, 0.55, 0.6, 0.75);
+    _composer.addPass(_bloom);
 
-    // Film grain + subtle scanline noise
-    const film = new FilmPass(0.3);
+    // Film grain + very subtle scanlines — SEL CRT feel without obscuring detail
+    // noiseIntensity 0.25, scanlineIntensity 0.04 (almost invisible scanlines)
+    const film = new FilmPass(0.25, false);
+    // FilmPass r169 takes (noiseIntensity, grayscale)
+    // scanlines are rendered by psx.css body.scanlines::before; keep FilmPass for grain only
     _composer.addPass(film);
 
-    // Glitch — disabled by default; only fires on state transitions
+    // Glitch — disabled by default; only fires on state transitions (~200 ms burst)
     _glitchPass = new GlitchPass();
     _glitchPass.enabled = false;
     _composer.addPass(_glitchPass);
 
-    // Linear → sRGB output
+    // Linear → sRGB output conversion
     _composer.addPass(new OutputPass());
 }
 
@@ -63,12 +71,24 @@ export function triggerGlitch() {
 }
 
 /**
+ * Resize the EffectComposer to match new canvas dimensions.
+ * Call from ResizeObserver or window.resize.
+ * @param {number} width
+ * @param {number} height
+ */
+export function onEffectsResize(width, height) {
+    if (!_composer) return;
+    _composer.setSize(width, height);
+    if (_bloom) _bloom.resolution.set(width, height);
+}
+
+/**
  * Render one frame through the composer.
- * Call this instead of renderer.render() when effects are active.
+ * Call instead of renderer.render() when effects are active.
  */
 export function renderFrame() {
     if (_composer) _composer.render();
 }
 
 // Expose on window for classic-script consumers (app.js, etc.)
-window.vrmEffects = { initEffects, triggerGlitch, renderFrame };
+window.vrmEffects = { initEffects, triggerGlitch, renderFrame, onEffectsResize };


### PR DESCRIPTION
Closes #95. Part of parent issue #90.

## Changes

### `frontend/js/atmosphere-vrm.js` (NEW)
- **Background plane** — `PlaneGeometry` with vertex colours: deep navy `#0a0a1a` (bottom) → dark purple `#16082e` (top), always behind the VRM scene (`renderOrder = -1`)
- **Particle system** — 800 `THREE.Points` in a tight volume around the character:
  - Colours: cyan / cornflower blue / lavender / periwinkle (random per-particle)
  - Additive blending, transparent, no depth write
  - Upward drift (0.025–0.08 units/s), gentle sine sway on X
  - Particles wrap: exit top → respawn at bottom (continuous loop)
  - Opacity pulses gently (0.38–0.52) to breathe with the scene

### `frontend/js/effects-vrm.js` (updated)
- UnrealBloomPass tuned: strength 0.55, radius 0.6, threshold 0.75 — bright highlights glow without blowing out
- FilmPass: noiseIntensity 0.25, grayscale off — grain-only (CSS scanlines handled by `psx.css`)
- Added `onEffectsResize(w, h)` — keeps composer + bloom resolution in sync on canvas resize

### `frontend/js/character-vrm.js` (updated)
- Imports `initAtmosphere`, `updateAtmosphere`, `onEffectsResize`
- `initAtmosphere(scene)` called after `initEffects()` in `_setupRenderer()`
- `updateAtmosphere(delta, t)` called in `_animate()` every tick
- ResizeObserver now also calls `onEffectsResize(width, height)`

## Visual result
- Character sits in front of a dark moody gradient background
- Subtle particles float upward in the ambient space — visible but not distracting
- Bloom gives a soft glow to Lain's rim light + bright highlights
- Film grain adds texture without obscuring the cel-shading
- GlitchPass fires ~200ms on every state transition (unchanged from Phase 1)