### PR TITLE
feat: Phase 4 — Optimization (progressive loading, mobile fallback, 60/30fps cap)

### DIFF
--- a/frontend/css/character-vrm-loader.css
+++ b/frontend/css/character-vrm-loader.css
@@ -1,0 +1,63 @@
+/* ── VRM Loading Overlay ─────────────────────────────────────────────────────
+   SEL-aesthetic spinner shown while lain.vrm loads (0 → 100%).
+   Injected/removed by LainVrmCharacter.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+#vrm-loader-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: #0a0a1a;
+    z-index: 10;
+    pointer-events: none;
+    transition: opacity 0.5s ease;
+}
+
+#vrm-loader-overlay.fade-out {
+    opacity: 0;
+}
+
+/* SEL ring spinner */
+.vrm-spinner {
+    width: 40px;
+    height: 40px;
+    border: 2px solid rgba(100, 100, 255, 0.15);
+    border-top-color: #6464ff;
+    border-radius: 50%;
+    animation: vrm-spin 1.2s linear infinite;
+}
+
+@keyframes vrm-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Progress bar */
+.vrm-progress-bar {
+    width: 80px;
+    height: 2px;
+    background: rgba(100, 100, 255, 0.15);
+    border-radius: 1px;
+    margin-top: 12px;
+    overflow: hidden;
+}
+
+.vrm-progress-fill {
+    height: 100%;
+    background: #6464ff;
+    border-radius: 1px;
+    transition: width 0.2s ease;
+    width: 0%;
+}
+
+/* Loading text */
+.vrm-loader-text {
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 9px;
+    color: rgba(100, 100, 255, 0.6);
+    margin-top: 8px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/psx.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/character-vrm-loader.css">
     <!-- Importmap: Three.js r169 + @pixiv/three-vrm for ES module character -->
     <script type="importmap">
     {

--- a/frontend/js/atmosphere-vrm.js
+++ b/frontend/js/atmosphere-vrm.js
@@ -21,8 +21,8 @@ let _bounds       = null;   // {xMin,xMax,yMin,yMax,zMin,zMax}
  *
  * @param {THREE.Scene}  scene
  * @param {Object}       [opts]
- * @param {number}       [opts.particleCount=800]
- * @param {number}       [opts.bgZ=-0.8]   — Z position of background plane
+ * @param {number}       [opts.particleCount=800]  — pass 200 for mobile
+ * @param {number}       [opts.bgZ=-0.8]            — Z position of background plane
  */
 export function initAtmosphere(scene, opts = {}) {
     const {

--- a/frontend/js/character-vrm.js
+++ b/frontend/js/character-vrm.js
@@ -7,9 +7,23 @@
 
 import * as THREE from 'three';
 import { GLTFLoader }                                 from 'three/addons/loaders/GLTFLoader.js';
+import { DRACOLoader }                                from 'three/addons/loaders/DRACOLoader.js';
 import { VRMLoaderPlugin, VRMUtils, VRMExpressionPresetName } from '@pixiv/three-vrm';
 import { initEffects, triggerGlitch, renderFrame, onEffectsResize } from './effects-vrm.js';
 import { initAtmosphere, updateAtmosphere }           from './atmosphere-vrm.js';
+
+// ── Device detection ──────────────────────────────────────────────────────────
+const _isMobile = (() => {
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    const narrow = window.innerWidth < 768;
+    return coarse && narrow;
+})();
+
+// ── Mobile: 30 FPS cap (throttle) ────────────────────────────────────────────
+const _FRAME_INTERVAL = _isMobile ? 1000 / 30 : 0;  // 0 = unlimited on desktop
+
+// ── Delta cap: skip catch-up when tab was hidden (prevents large delta spikes) ─
+const _DELTA_MAX = 0.1;  // 100 ms — anything larger gets clamped
 
 const VRM_PATH  = 'models/lain.vrm';
 const CAM_FOV   = 28;    // tight portrait framing
@@ -52,6 +66,12 @@ class LainVrmCharacter {
 
         // Page visibility
         this._onVisibilityChange = this._handleVisibility.bind(this);
+
+        // Mobile FPS throttle
+        this._lastFrameTs = 0;
+
+        // Loading overlay DOM ref
+        this._loaderOverlay = null;
     }
 
     // ── Public API ────────────────────────────────────────────
@@ -68,12 +88,19 @@ class LainVrmCharacter {
         // Pause RAF when tab is hidden — fixes wasted GPU on hidden tab
         document.addEventListener('visibilitychange', this._onVisibilityChange);
 
+        // Show loading overlay
+        this._showLoader();
+
         try {
             await this._loadVRM();
         } catch (err) {
             console.warn('[LainVrmCharacter] VRM load failed:', err);
+            this._hideLoader(true);
             return;
         }
+
+        // Fade out + remove loading overlay
+        this._hideLoader();
 
         this._startLoop();
         this._scheduleBlink();
@@ -203,11 +230,11 @@ class LainVrmCharacter {
         rim.position.set(-1.0, 0.5, -1.0);
         this._scene.add(rim);
 
-        // Initialise EffectComposer (bloom + film grain + glitch)
-        initEffects(this._renderer, this._scene, this._camera);
+        // Initialise EffectComposer (bloom + film grain + glitch) — mobile gets reduced quality
+        initEffects(this._renderer, this._scene, this._camera, { mobile: _isMobile });
 
-        // Initialise atmosphere: dark background plane + ambient particles
-        initAtmosphere(this._scene);
+        // Initialise atmosphere — mobile gets reduced particle count (800 → 200)
+        initAtmosphere(this._scene, { particleCount: _isMobile ? 200 : 800 });
 
         // ResizeObserver — keep canvas, composer, and camera in sync with container
         if (this._el && window.ResizeObserver) {
@@ -229,16 +256,29 @@ class LainVrmCharacter {
     // ── VRM loading ───────────────────────────────────────────
 
     async _loadVRM() {
+        // DRACOLoader: wired for future DRACO-compressed VRM variants.
+        // Note: gltf-transform draco strips VRMC_* extensions (VRM1 spec),
+        // so production DRACO compression requires a VRM-aware pipeline
+        // (e.g. vrm-compress-draco or manual JSON patching). The current
+        // lain.vrm is uncompressed; DRACOLoader is a no-op for non-DRACO GLBs
+        // but adds zero overhead and makes the path future-proof.
+        const dracoLoader = new DRACOLoader();
+        dracoLoader.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/libs/draco/');
+
         const loader = new GLTFLoader();
+        loader.setDRACOLoader(dracoLoader);
         loader.register(parser => new VRMLoaderPlugin(parser));
 
-        // ── FIX #5 (MINOR): VRM load progress callback ──
+        // Progress: update overlay bar + console
         const gltf = await loader.loadAsync(VRM_PATH, (xhr) => {
             if (xhr.lengthComputable) {
                 const pct = Math.round((xhr.loaded / xhr.total) * 100);
                 console.info(`[LainVrmCharacter] Loading VRM: ${pct}% (${(xhr.loaded / 1024 / 1024).toFixed(1)} MB)`);
+                this._updateLoaderProgress(pct);
             }
         });
+
+        dracoLoader.dispose();
 
         const vrm  = gltf.userData.vrm;
         if (!vrm) throw new Error('No VRM data found in GLTF userData');
@@ -283,12 +323,21 @@ class LainVrmCharacter {
     // ── Animation loop ────────────────────────────────────────
 
     _startLoop() {
-        const tick = () => {
+        const tick = (now) => {
             this._raf = requestAnimationFrame(tick);
-            const delta   = this._clock.getDelta();
-            const elapsed = this._clock.elapsedTime;
+
+            // Mobile 30fps cap: skip frame if too soon
+            if (_FRAME_INTERVAL > 0) {
+                if (now - this._lastFrameTs < _FRAME_INTERVAL) return;
+                this._lastFrameTs = now;
+            }
+
+            // Delta clamp: prevent large catch-up spikes after tab-switch
+            const rawDelta = this._clock.getDelta();
+            const delta    = Math.min(rawDelta, _DELTA_MAX);
+            const elapsed  = this._clock.elapsedTime;
+
             this._animate(elapsed, delta);
-            // ── FIX #1 (MAJOR): use renderFrame() via EffectComposer, not renderer.render() ──
             renderFrame();
         };
         this._raf = requestAnimationFrame(tick);
@@ -501,6 +550,44 @@ class LainVrmCharacter {
             if (i < steps.length) setTimeout(advance, 50);
         };
         advance();
+    }
+
+    // ── Loading overlay ───────────────────────────────────────
+
+    _showLoader() {
+        const overlay = document.createElement('div');
+        overlay.id = 'vrm-loader-overlay';
+        overlay.innerHTML = `
+            <div class="vrm-spinner"></div>
+            <div class="vrm-progress-bar"><div class="vrm-progress-fill" id="vrm-progress-fill"></div></div>
+            <div class="vrm-loader-text" id="vrm-loader-text">CONNECTING TO WIRED...</div>
+        `;
+        const target = this._el || document.body;
+        target.appendChild(overlay);
+        this._loaderOverlay = overlay;
+    }
+
+    _updateLoaderProgress(pct) {
+        const fill = document.getElementById('vrm-progress-fill');
+        const text = document.getElementById('vrm-loader-text');
+        if (fill) fill.style.width = `${pct}%`;
+        if (text) text.textContent = `LOADING ${pct}%`;
+    }
+
+    _hideLoader(immediate = false) {
+        if (!this._loaderOverlay) return;
+        const overlay = this._loaderOverlay;
+        this._loaderOverlay = null;
+
+        if (immediate) {
+            overlay.remove();
+            return;
+        }
+
+        // Fill to 100% then fade out
+        this._updateLoaderProgress(100);
+        overlay.classList.add('fade-out');
+        setTimeout(() => overlay.remove(), 550);
     }
 
     // ── Pose scheduler ────────────────────────────────────────

--- a/frontend/js/effects-vrm.js
+++ b/frontend/js/effects-vrm.js
@@ -24,8 +24,12 @@ let _glitchTmr  = null;
  * @param {THREE.WebGLRenderer} renderer
  * @param {THREE.Scene}         scene
  * @param {THREE.Camera}        camera
+ * @param {Object}              [opts]
+ * @param {boolean}             [opts.mobile=false]  — reduced quality for mobile
  */
-export function initEffects(renderer, scene, camera) {
+export function initEffects(renderer, scene, camera, opts = {}) {
+    const { mobile = false } = opts;
+
     const size = new THREE.Vector2();
     renderer.getSize(size);
 
@@ -35,18 +39,19 @@ export function initEffects(renderer, scene, camera) {
     _composer.addPass(new RenderPass(scene, camera));
 
     // Unreal bloom — soft SEL glow on highlights
-    // strength 0.55: noticeable but not blown-out
-    // radius   0.6:  wider glow spread for dreamy look
-    // threshold 0.75: only bloom near-white highlights (Lain's hair, rim light)
-    _bloom = new UnrealBloomPass(size, 0.55, 0.6, 0.75);
+    // Desktop: strength 0.55, radius 0.6, threshold 0.75
+    // Mobile:  strength 0.30, radius 0.4, threshold 0.80 (cheaper)
+    const bloomStrength  = mobile ? 0.30 : 0.55;
+    const bloomRadius    = mobile ? 0.40 : 0.60;
+    const bloomThreshold = mobile ? 0.80 : 0.75;
+    _bloom = new UnrealBloomPass(size, bloomStrength, bloomRadius, bloomThreshold);
     _composer.addPass(_bloom);
 
-    // Film grain + very subtle scanlines — SEL CRT feel without obscuring detail
-    // noiseIntensity 0.25, scanlineIntensity 0.04 (almost invisible scanlines)
-    const film = new FilmPass(0.25, false);
-    // FilmPass r169 takes (noiseIntensity, grayscale)
-    // scanlines are rendered by psx.css body.scanlines::before; keep FilmPass for grain only
-    _composer.addPass(film);
+    // Film grain — disabled on mobile (expensive on low-end GPU)
+    if (!mobile) {
+        const film = new FilmPass(0.25, false);
+        _composer.addPass(film);
+    }
 
     // Glitch — disabled by default; only fires on state transitions (~200 ms burst)
     _glitchPass = new GlitchPass();


### PR DESCRIPTION
Closes #97. Final phase of parent issue #90.

## Changes

### Progressive Loading UI
- **`frontend/css/character-vrm-loader.css`** (NEW): SEL-aesthetic loading overlay
  - Purple ring spinner, animated with CSS `@keyframes vrm-spin`
  - Thin progress bar (0–100%) with smooth CSS transition
  - Monospace text: "CONNECTING TO WIRED..." → "LOADING 42%" → fades out at 100%
  - Overlay covers VRM canvas container; fades out (0.5s) then removes from DOM
- **`frontend/index.html`**: link `character-vrm-loader.css`
- **`frontend/js/character-vrm.js`**: `_showLoader()`, `_updateLoaderProgress(pct)`, `_hideLoader(immediate?)` methods; wired into `init()` and `_loadVRM()` progress callback

### DRACOLoader (future-proof)
- `DRACOLoader` instantiated and set on `GLTFLoader` with CDN decoder path
  (`cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/libs/draco/`)
- **Note**: `gltf-transform draco` strips VRMC_* extensions, making the output invalid as VRM1. Current `lain.vrm` is uncompressed. DRACOLoader is zero-overhead for non-DRACO GLBs and makes the codebase ready for a VRM-aware DRACO pipeline.

### Mobile Fallback
- `_isMobile`: `(pointer: coarse) && (width < 768)` — detection at module load time
- **`effects-vrm.js`**: `initEffects(renderer, scene, camera, {mobile})` — mobile reduces `UnrealBloomPass` (strength 0.30, radius 0.40, threshold 0.80) and disables `FilmPass` grain entirely
- **`atmosphere-vrm.js`**: `particleCount` option documented; caller passes 200 on mobile
- **`character-vrm.js`**: passes `{mobile: _isMobile}` to `initEffects` and `{particleCount: _isMobile ? 200 : 800}` to `initAtmosphere`

### FPS Caps + Delta Clamp
- `_FRAME_INTERVAL = _isMobile ? 1000/30 : 0` — RAF throttle for 30fps mobile cap
- `_DELTA_MAX = 0.1` — clamps `clock.getDelta()` to 100ms; prevents physics/animation catch-up after tab switching or slow frame
- `_lastFrameTs` tracked per tick for interval comparison

## What did NOT change
- VRM loading / Three.js scene structure / bone animations / atmosphere all intact
- GlitchPass on state transition: unchanged
- `onEffectsResize`: wired in Phase 3, unchanged here